### PR TITLE
require action and history in notify()

### DIFF
--- a/snewpdag/plugins/CombineMaps.py
+++ b/snewpdag/plugins/CombineMaps.py
@@ -58,14 +58,6 @@ class CombineMaps(Node):
     # start constructing output data.
     ndata = {}
 
-    # first, see if there is any valid data.  if so, alert. otherwise revoke.
-    hlist = []
-    for k in self.map:
-      if self.map[k]['valid']:
-        hlist.append(self.map[k]['history'])
-    ndata['action'] = 'revoke' if len(hlist) == 0 else 'alert'
-    ndata['history'] = tuple(hlist)
-
     # if all maps are chi2, then can output chi2
     use_chi2 = not self.force_cl
     if use_chi2:
@@ -123,5 +115,10 @@ class CombineMaps(Node):
       ndata['cl'] = m
 
     # notify
-    self.notify(ndata)
+    hlist = []
+    for k in self.map:
+      if self.map[k]['valid']:
+        hlist.append(self.map[k]['history'])
+    action_verb = 'revoke' if len(hlist) == 0 else 'alert'
+    self.notify(action_verb, tuple(hlist), ndata)
 

--- a/snewpdag/plugins/NthTimeDiff.py
+++ b/snewpdag/plugins/NthTimeDiff.py
@@ -50,14 +50,10 @@ class NthTimeDiff(Node):
 
     # do the calculation if we have two valid inputs.
     if self.valid == [ True, True ]:
-      ndata = { 'action': 'alert',
-                'history': ( self.h[0], self.h[1] ),
-                'dt': self.t[0] - self.t[1] }
-      self.notify(ndata)
+      self.notify('alert', ( self.h[0], self.h[1] ),
+                  { 'dt': self.t[0] - self.t[1] } )
     elif newrevoke:
-      ndata = { 'action': 'revoke',
-                'history': ( self.h[0], self.h[1] ) }
-      self.notify(ndata)
+      self.notify('revoke', ( self.h[0], self.h[1] ), {})
 
   def get_nth(self, values):
     """

--- a/snewpdag/plugins/StdOutput.py
+++ b/snewpdag/plugins/StdOutput.py
@@ -15,7 +15,7 @@ class StdOutput(Node):
     print('**** {} ****'.format(self.name))
     self.print_dict('', data)
     print('---- {} ----'.format(self.name))
-    self.notify(data)
+    self.notify(data['action'], None, data)
 
   def print_dict(self, indent, data):
     for k, v in data.items():

--- a/snewpdag/plugins/TimeDistDiff.py
+++ b/snewpdag/plugins/TimeDistDiff.py
@@ -47,15 +47,6 @@ class TimeDistDiff(Node):
 
     # start constructing output data.
     ndata = {}
-
-    # first, see if there are at least two valid data sets.  if so, alert. otherwise revoke.
-    hlist = []
-    for k in self.map:
-      if self.map[k]['valid']:
-        hlist.append(self.map[k]['history'])
-    ndata['action'] = 'revoke' if len(hlist) <= 1 else 'alert'
-    ndata['history'] = tuple(hlist)
-
     ndata['tdelay'] = {}
     # do the calculation
     for i in self.map:
@@ -65,7 +56,12 @@ class TimeDistDiff(Node):
                 ndata['tdelay'][(i,j)] = gettdelay(self.map[i]['t'],self.map[i]['n'],self.map[j]['t'],self.map[j]['n'])
 
     # notify
-    self.notify(ndata)
+    hlist = []
+    for k in self.map:
+      if self.map[k]['valid']:
+        hlist.append(self.map[k]['history'])
+    action_verb = 'revoke' if len(hlist) <= 1 else 'alert'
+    self.notify(action_verb, tuple(hlist), ndata)
 
 def normalizeforchi2(n1):
     n1 = n1-np.mean(n1[0:int(len(n1)/10)]) #background is concidered in the first 10% of the data

--- a/snewpdag/plugins/TimeDistFileInput.py
+++ b/snewpdag/plugins/TimeDistFileInput.py
@@ -35,12 +35,12 @@ class TimeDistFileInput(Node):
             tt, nn = self.read_tn(data['filename'])
           data['t'] = tt
           data['n'] = nn
-          self.notify(data)
+          self.notify(data['action'], None, data)
         else:
           logging.error('[{}] Missing filename'.format(self.name))
           return
       else:
-        self.notify(data)
+        self.notify(data['action'], None, data)
     else:
       logging.error('[{}] Expected action field not found'.format(self.name))
 

--- a/snewpdag/plugins/TimeDistInput.py
+++ b/snewpdag/plugins/TimeDistInput.py
@@ -27,7 +27,7 @@ class TimeDistInput(Node):
         if 't' in data and 'n' in data:
           if len(data['t']) == len(data['n']):
             logging.info("[{}] notify called".format(self.name))
-            self.notify(data)
+            self.notify(data['action'], None, data)
           else:
             logging.error('[{}] t and n length mistmatch'.format(self.name))
         else:

--- a/snewpdag/plugins/TimeSeriesInput.py
+++ b/snewpdag/plugins/TimeSeriesInput.py
@@ -27,7 +27,7 @@ class TimeSeriesInput(Node):
     """
     if 'action' in data:
       if data['action'] != 'alert' or 'times' in data:
-        self.notify(data)
+        self.notify(data['action'], None, data)
       else:
         logging.error('[{}] Expected times field not found'.format(self.name))
     else:

--- a/snewpdag/tests/test_basic_node.py
+++ b/snewpdag/tests/test_basic_node.py
@@ -35,29 +35,29 @@ class TestBasicNode(unittest.TestCase):
     self.n1.attach(self.n2)
     self.n1.attach(self.n3)
     self.n2.attach(self.n4)
-    data = { 'k': 'v' }
+    data = { 'action': 'alert', 'k': 'v' }
     self.n1.update(data)
     self.assertEqual(self.n1.last_data,
-                     { 'k':'v', 'history':('node1',) })
+                     { 'action': 'alert', 'k':'v', 'history':('node1',) })
     self.assertEqual(self.n2.last_data,
-                     { 'k':'v', 'history':('node1','node2') })
+                     { 'action': 'alert', 'k':'v', 'history':('node1','node2') })
     self.assertEqual(self.n3.last_data,
-                     { 'k':'v', 'history':('node1','node3') })
+                     { 'action': 'alert', 'k':'v', 'history':('node1','node3') })
     self.assertEqual(self.n4.last_data,
-                     { 'k':'v', 'history':('node1','node2','node4') })
+                     { 'action': 'alert', 'k':'v', 'history':('node1','node2','node4') })
 
   def test_history_order(self):
     self.n1.attach(self.n3)
     self.n1.attach(self.n2)
     self.n3.attach(self.n4)
-    data = { 'k': 'v' }
+    data = { 'action': 'alert', 'k': 'v' }
     self.n1.update(data)
     self.assertEqual(self.n1.last_data,
-                     { 'k':'v', 'history':('node1',) })
+                     { 'action': 'alert', 'k':'v', 'history':('node1',) })
     self.assertEqual(self.n2.last_data,
-                     { 'k':'v', 'history':('node1','node2') })
+                     { 'action': 'alert', 'k':'v', 'history':('node1','node2') })
     self.assertEqual(self.n3.last_data,
-                     { 'k':'v', 'history':('node1','node3') })
+                     { 'action': 'alert', 'k':'v', 'history':('node1','node3') })
     self.assertEqual(self.n4.last_data,
-                     { 'k':'v', 'history':('node1','node3','node4') })
+                     { 'action': 'alert', 'k':'v', 'history':('node1','node3','node4') })
 


### PR DESCRIPTION
This PR changes the Node.notify() method to require an action verb and history, instead of relying on the node to pass them in as dictionary entries in the data.