### PR TITLE
Add burst and experiment id to renderers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ runtest:
           snewpdag/data/text-flux-config.json
 
 trial:
-	python snewpdag/trials/Normal.py hist | \
+	python snewpdag/trials/Normal.py hist --expt Newt | \
           python -m snewpdag --jsonlines \
           snewpdag/data/test-dags-hist-config.json
 

--- a/snewpdag/plugins/renderers/Histogram1D.py
+++ b/snewpdag/plugins/renderers/Histogram1D.py
@@ -1,7 +1,23 @@
 """
 1D Histogram renderer
 
+Configuration options:
+  title:  histogram title (top of plot)
+  xlabel:  x axis label
+  ylabel:  y axis label
+  filename:  output filename, with fields
+             {0} renderer name
+             {1} count index, starting from 0
+             {2} id from update data (default 0 if no such field)
+
 Might be nice to allow options to be configured here as well.
+
+Input data:
+  action - only respond to 'report'
+  id - burst id
+  histogram.xlow
+  histogram.xhigh
+  histogram.bins - uniform bin contents
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,7 +33,7 @@ class Histogram1D(Node):
     self.count = 0 # number of histograms made
     super().__init__(**kwargs)
 
-  def render(self, xlo, xhi, bins):
+  def render(self, burst_id, xlo, xhi, bins):
     n = len(bins)
     step = (xhi - xlo) / n
     x = np.arange(xlo, xhi, step)
@@ -30,7 +46,7 @@ class Histogram1D(Node):
     ax.set_title(self.title)
     fig.tight_layout()
 
-    fname = self.filename.format(self.name, self.count)
+    fname = self.filename.format(self.name, self.count, burst_id)
     plt.savefig(fname)
     self.count += 1
 
@@ -38,6 +54,7 @@ class Histogram1D(Node):
     action = data['action']
     if action == 'report':
       h = data['histogram']
-      self.render(h['xlow'], h['xhigh'], h['bins'])
+      burst_id = data['id'] if 'id' in data else 0
+      self.render(burst_id, h['xlow'], h['xhigh'], h['bins'])
     self.notify(action, None, data)
 

--- a/snewpdag/plugins/renderers/TimeProfile.py
+++ b/snewpdag/plugins/renderers/TimeProfile.py
@@ -1,8 +1,19 @@
 """
 Time profile renderer.
 
+Configuration options:
+  title:  profile title (top of plot)
+  xfield:  name of data field for x values
+  yfield:  name of data field for y values
+  xlabel:  x axis label
+  ylabel:  y axis label
+  filename:  output filename, with fields
+             {0} renderer name
+             {1} count index, starting from 0
+             {2} id from update data (default 0 if no such field)
+             {3} source name (which this renderer observes)
+
 Plots y vs x.
-Filename arguments:  name, source, count
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,7 +31,7 @@ class TimeProfile(Node):
     self.count = 0 # number of histograms made
     super().__init__(**kwargs)
 
-  def render(self, source, x, y, subtitle):
+  def render(self, burst_id, source, x, y, subtitle):
     fig, ax = plt.subplots()
     ax.plot(x, y)
     ax.set_xlabel(self.xlabel)
@@ -28,16 +39,17 @@ class TimeProfile(Node):
     ax.set_title(self.title + '(' + subtitle + ')')
     fig.tight_layout()
 
-    fname = self.filename.format(self.name, source, self.count)
+    fname = self.filename.format(self.name, self.count, burst_id, source)
     plt.savefig(fname)
     self.count += 1
 
   def update(self, data):
     action = data['action']
     if action == 'report' or action == 'alert':
+      burst_id = data['id'] if 'id' in data else 0
       nm = data['name']
       if 'comment' in data:
         nm += ": " + data['comment']
-      self.render(data['history'][-1], data[self.xfield], data[self.yfield], nm)
+      self.render(burst_id, data['history'][-1], data[self.xfield], data[self.yfield], nm)
     self.notify(action, None, data)
 

--- a/snewpdag/trials/Normal.py
+++ b/snewpdag/trials/Normal.py
@@ -18,6 +18,7 @@ def run():
   parser.add_argument('--mean', default=0.0, help='mean value')
   parser.add_argument('--rms', default=1.0, help='rms value')
   parser.add_argument('--field', default='x', help='field name to generate')
+  parser.add_argument('--expt', default='Normal', help='experiment name')
   args = parser.parse_args()
 
   i = 0
@@ -26,7 +27,7 @@ def run():
   rms = float(args.rms)
   rng = np.random.default_rng()
   while i < imax:
-    data = { 'action': 'alert', 'name': args.name }
+    data = { 'action': 'alert', 'name': args.name, 'id': i, 'expt': args.expt }
     data[args.field] = rng.normal(mean, rms)
     print(json.dumps(data))
     i += 1


### PR DESCRIPTION
Add some information to renderer plugins, so they can generate filenames for individual pseudo-experiments, or ensembles of pseudo-experiments.
