### PR TITLE
simplify watch index lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ trial:
 
 trial2:
 	python snewpdag/trials/Simple.py Control -n 10 | \
-          python -m snewpdag --jsonlines snewpdag/data/test-liq-config.py
+          python -m snewpdag --log INFO --jsonlines snewpdag/data/test-liq-config.py
 
 init:
 	pip install -r requirements.txt

--- a/snewpdag/dag/Node.py
+++ b/snewpdag/dag/Node.py
@@ -18,6 +18,7 @@ class Node:
     self.observers = []  # observers of this Node
     self.watch_list = [] # nodes this Node is observing
     self.last_data = {}  # data after last update
+    self.last_source = None # source of last update
 
   def dispose(self):
     """
@@ -152,6 +153,8 @@ class Node:
     logging.debug('{0}: update({1})'.format(self.name,
                   data['action'] if 'action' in data else 'None'))
     cdata = data.copy() # local shallow copy
+    if 'history' in cdata and len(cdata['history']) > 0:
+      self.last_source = cdata['history'][-1]
     if 'action' in cdata:
       action = cdata['action']
       v = False
@@ -190,5 +193,13 @@ class Node:
     for i in range(len(self.watch_list)):
       if source == self.watch_list[i].name:
         return i
+
+    logging.error('{}: unrecognized source {}'.format(self.name, source))
+    return -1
+
+  def last_watch_index(self):
+    if self.last_source:
+      return self.watch_index(self.last_source)
+    logging.error('{}: no payload source'.format(self.name))
     return -1
 


### PR DESCRIPTION
Now one can use last_watch_index() in the action methods, which gives you the index of the source, without having to pull the name out of the history.

NthTimeDiff also rewritten to separate into action methods rather than using the old update() method.
