### PR TITLE
Running trials on python command line

### DIFF
--- a/snewpdag/plugins/gen/Combine.py
+++ b/snewpdag/plugins/gen/Combine.py
@@ -66,7 +66,7 @@ class Combine(Node):
       data['t_bins'] = tb
       data['t_bins'].flags.writeable = False
    
-    print(data['t_true'])
+    #print(data['t_true'])
     #exit()
     return True
 

--- a/snewpdag/trials/SimpleTrials.py
+++ b/snewpdag/trials/SimpleTrials.py
@@ -1,0 +1,43 @@
+"""
+SimpleTrials - run MC trials directly into a DAG
+
+This duplicates piping Simple.py output into the snewpdag module,
+but without having to pipe in the shell.
+
+spec can be constructed by hand, or by reading from a configuration file.
+
+To read a python-formatted configuration file,
+
+  import snewpdag.SimpleTrials import trials
+  import ast
+  with open(filename, 'r') as f:
+    spec = ast.literal_eval(f.read())
+  trials(spec)
+
+To read a csv-formatted configuration file,
+
+  import snewpdag.SimpleTrials import trials
+  from snewpdag.dag.app import csv_eval
+  with open(filename, 'r') as f:
+    spec = csv_eval(f)
+  trials(spec)
+"""
+import sys
+from snewpdag.dag.app import configure, inject
+
+def trials(spec, ntrials=1000):
+  """
+  Configure nodes using spec (a list of dictionaries).
+  Then run alert/reset pairs for as many times as given in ntrials,
+  followed by a report action.
+  """
+  nodes = configure(spec)
+  i = 0
+  while i < ntrials:
+    data = [ { 'action': 'alert', 'id': i, 'name': 'Control' },
+             { 'action': 'reset', 'id': i, 'name': 'Control' } ]
+    inject(nodes, data, spec)
+    i += 1
+  data = [ { 'action': 'report', 'name': 'Control' } ]
+  inject(nodes, data, spec)
+

--- a/snewpdag/trials/__init__.py
+++ b/snewpdag/trials/__init__.py
@@ -1,4 +1,1 @@
 
-from .Normal import Normal
-from .Simple import Simple
-


### PR DESCRIPTION
This pull request includes snewpdag/trials/SimpleTrials, which has a method trials() for running MC trials from within python.  It duplicates the functionality of piping Simple.py output into the snewpdag module, but may be easier to use within systems like Jupyter since you don't need the unix shell to mediate between them.
