### PR TITLE
Check that a node doesn't observe itself

### DIFF
--- a/snewpdag/tests/test_app.py
+++ b/snewpdag/tests/test_app.py
@@ -108,3 +108,21 @@ class TestApp(unittest.TestCase):
     self.assertEqual(nodes[0]['Diff3'].last_data['action'], 'alert')
     self.assertAlmostEqual(nodes[0]['Diff3'].last_data['dt'], -0.7)
 
+  def test_cyclic_error(self):
+    spec = [
+      { 'class': 'TimeSeriesInput', 'name': 'Input1' },
+      { 'class': 'TimeSeriesInput', 'name': 'Input2' },
+      { 'class': 'NthTimeDiff',
+        'name': 'Diff1',
+        'kwargs': { 'nth': 1 },
+        'observe': [ 'Input1', 'Diff1' ] }, # should be an error
+      { 'class': 'NthTimeDiff',
+        'name': 'Diff3',
+        'kwargs': { 'nth': 3 },
+        'observe': [ 'Input1', 'Input2' ] },
+      ]
+    with self.assertLogs() as cm:
+      nodes = configure(spec)
+    self.assertEqual(cm.output, [
+        'ERROR:root:Diff1 observing itself' ])
+

--- a/snewpdag/trials/Simple.py
+++ b/snewpdag/trials/Simple.py
@@ -19,8 +19,8 @@ def run():
   i = 0
   imax = int(args.number)
   while i < imax:
-    print(json.dumps({ 'action': 'alert', 'id': i, 'name': args.name }))
-    print(json.dumps({ 'action': 'reset', 'id': i, 'name': args.name }))
+    print(json.dumps({ 'action': 'alert', 'burst_id': i, 'name': args.name }))
+    print(json.dumps({ 'action': 'reset', 'burst_id': i, 'name': args.name }))
     i += 1
   print(json.dumps({ 'action': 'report', 'name': args.name }))
 

--- a/snewpdag/trials/SimpleTrials.py
+++ b/snewpdag/trials/SimpleTrials.py
@@ -32,10 +32,14 @@ def trials(spec, ntrials=1000):
   followed by a report action.
   """
   nodes = configure(spec)
+  if nodes == None:
+    logging.error('Invalid configuration specified')
+    return
+
   i = 0
   while i < ntrials:
-    data = [ { 'action': 'alert', 'id': i, 'name': 'Control' },
-             { 'action': 'reset', 'id': i, 'name': 'Control' } ]
+    data = [ { 'action': 'alert', 'burst_id': i, 'name': 'Control' },
+             { 'action': 'reset', 'burst_id': i, 'name': 'Control' } ]
     inject(nodes, data, spec)
     i += 1
   data = [ { 'action': 'report', 'name': 'Control' } ]


### PR DESCRIPTION
@calhewitt noticed that a node could observe itself, introducing a cycle into what's supposed to be an acyclic graph. This PR adds a check in app.configure against that.

Also changed id to burst_id in Simple.py and SimpleTrials.py
