### PR TITLE
Filter on value in payload field

### DIFF
--- a/snewpdag/plugins/FilterValue.py
+++ b/snewpdag/plugins/FilterValue.py
@@ -1,0 +1,42 @@
+"""
+FilterValue - check that a payload key gives a certain value.
+If not, consume the action.
+
+Constructor arguments:
+  in_field: string, name of field to check
+  value: value to check against
+  on_alert, on_reset, on_revoke, on_report: boolean, optional,
+    run check on these actions, else pass through (return True)
+"""
+import logging
+
+from snewpdag.dag import Node
+
+class FilterValue(Node):
+  def __init__(self, in_field, value, **kwargs):
+    self.in_field = in_field
+    self.value = value
+    self.on_alert = kwargs.pop('on_alert', True)
+    self.on_reset = kwargs.pop('on_reset', False)
+    self.on_revoke = kwargs.pop('on_revoke', False)
+    self.on_report = kwargs.pop('on_report', False)
+    super().__init__(**kwargs)
+
+  def check_value(self, data):
+    if self.in_field in data:
+      return data[self.in_field] == self.value
+    else:
+      return False
+
+  def alert(self, data):
+    return self.check_value(data) if self.on_alert else True
+
+  def revoke(self, data):
+    return self.check_value(data) if self.on_revoke else True
+
+  def reset(self, data):
+    return self.check_value(data) if self.on_reset else True
+
+  def report(self, data):
+    return self.check_value(data) if self.on_report else True
+

--- a/snewpdag/tests/test_filter.py
+++ b/snewpdag/tests/test_filter.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for Filter plugins
+"""
+import unittest
+
+from snewpdag.plugins import FilterValue
+
+class TestFilter(unittest.TestCase):
+
+  def test_filter_value(self):
+    fv = FilterValue('test', 10.0, name='fv0')
+    data = { 'action': 'alert', 'test': 10.0 }
+    ret = fv.alert(data)
+    self.assertEqual(ret, True)
+    data = { 'action': 'alert', 'test': 11.0 }
+    ret = fv.alert(data)
+    self.assertEqual(ret, False)
+    data = { 'action': 'alert' }
+    ret = fv.alert(data)
+    self.assertEqual(ret, False)
+    # test pass-throughs
+    data = { 'action': 'reset' }
+    ret = fv.reset(data)
+    self.assertEqual(ret, True)
+    data = { 'action': 'revoke' }
+    ret = fv.revoke(data)
+    self.assertEqual(ret, True)
+    data = { 'action': 'report' }
+    ret = fv.report(data)
+    self.assertEqual(ret, True)
+
+  def test_filter_other_actions(self):
+    fv = FilterValue('test', 10.0, name='fv0', on_alert=False,
+                     on_reset=True, on_revoke=True, on_report=True)
+    data = { 'action': 'action' }
+    ret = fv.alert(data)
+    self.assertEqual(ret, True)
+    data = { 'action': 'reset', 'test': 10.0 }
+    ret = fv.reset(data)
+    self.assertEqual(ret, True)
+    data = { 'action': 'reset', 'test': 11.0 }
+    ret = fv.reset(data)
+    self.assertEqual(ret, False)
+    data = { 'action': 'reset' }
+    ret = fv.reset(data)
+    self.assertEqual(ret, False)
+    data = { 'action': 'revoke', 'test': 10.0 }
+    ret = fv.revoke(data)
+    self.assertEqual(ret, True)
+    data = { 'action': 'revoke', 'test': 11.0 }
+    ret = fv.revoke(data)
+    self.assertEqual(ret, False)
+    data = { 'action': 'revoke' }
+    ret = fv.revoke(data)
+    self.assertEqual(ret, False)
+    data = { 'action': 'report', 'test': 10.0 }
+    ret = fv.revoke(data)
+    self.assertEqual(ret, True)
+    data = { 'action': 'report', 'test': 11.0 }
+    ret = fv.revoke(data)
+    self.assertEqual(ret, False)
+    data = { 'action': 'report' }
+    ret = fv.revoke(data)
+    self.assertEqual(ret, False)
+


### PR DESCRIPTION
First version.

May need to check the validator plugins.  It appears the pass-throughs (e.g., for on_reset=False) always return False, but I think they should return True so the action is forwarded without any checks.
