### PR TITLE
MC trial utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ standalone_unittests:
 	python -m unittest snewpdag.tests.test_app
 	python -m unittest snewpdag.tests.test_inputs
 	python -m unittest snewpdag.tests.test_combinemaps
+	python -m unittest snewpdag.tests.test_copy
 
 test: standalone_unittests lightcurvesim
 	python -m unittest snewpdag.tests.test_timedistdiff
@@ -35,6 +36,12 @@ trial2:
 diffpointing:
 	python snewpdag/trials/Simple.py Control -n 1 | \
           python -m snewpdag --log INFO --jsonlines snewpdag/data/test-diff.py
+
+diffpointing_smear:
+	python snewpdag/trials/Simple.py Control -n 1 | \
+          python -m snewpdag --jsonlines snewpdag/data/test-diff-low-res.csv
+	python snewpdag/trials/Simple.py Control -n 10000 | \
+          python -m snewpdag --jsonlines snewpdag/data/test-diff-smear.csv
 
 distcalc_trial:
 	python snewpdag/trials/Simple.py Control -n 1000 | \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ diffpointing_smear:
 	python snewpdag/trials/Simple.py Control -n 10000 | \
           python -m snewpdag --jsonlines snewpdag/data/test-pointing.csv
 
+diffpointing_weighted:
+	python snewpdag/trials/Simple.py Control -n 1000 | \
+          python -m snewpdag --jsonlines snewpdag/data/test-pointing-weighted.csv
+
 distcalc_trial:
 	python snewpdag/trials/Simple.py Control -n 1000 | \
           python -m snewpdag --log INFO --jsonlines snewpdag/data/test-distcalc-single-config.csv

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,15 @@ trial2:
 
 diffpointing:
 	python snewpdag/trials/Simple.py Control -n 1 | \
-          python -m snewpdag --log INFO --jsonlines snewpdag/data/test-diff.py
+          python -m snewpdag --log INFO --jsonlines snewpdag/data/test-diff.csv
 
 diffpointing_smear:
-	python snewpdag/trials/Simple.py Control -n 1 | \
-          python -m snewpdag --jsonlines snewpdag/data/test-diff-low-res.csv
+	#python snewpdag/trials/Simple.py Control -n 1 | \
+        #  python -m snewpdag --jsonlines snewpdag/data/test-diff-low-res.csv
+	#python snewpdag/trials/Simple.py Control -n 10000 | \
+        #  python -m snewpdag --jsonlines snewpdag/data/test-diff-smear.csv
 	python snewpdag/trials/Simple.py Control -n 10000 | \
-          python -m snewpdag --jsonlines snewpdag/data/test-diff-smear.csv
+          python -m snewpdag --jsonlines snewpdag/data/test-pointing.csv
 
 distcalc_trial:
 	python snewpdag/trials/Simple.py Control -n 1000 | \

--- a/snewpdag/data/test-diff-low-res.csv
+++ b/snewpdag/data/test-diff-low-res.csv
@@ -1,0 +1,11 @@
+"Control","Pass",,"'line': 100"
+,,,
+"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':-60.0, 'dec':-30.0, 'smear': False, 'time':'2021-11-01 05:22:36.328'"
+"Gen-out","Pass","Gen","'line':1, 'dump':1"
+,,,
+"Diff","DiffPointing","Gen","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
+"Diff-out","Pass","Diff","'line':1, 'dump':1"
+,,,
+"conf","Chi2CL","Diff","'in_field':'map', 'out_field':'clmap'"
+"skymap","renderers.Mollview","conf","'in_field':'clmap', 'title':'DiffPointing', 'units':'CL', 'min':0, 'max':1, 'coord':['C'], 'filename':'output/test-diff-low-res-{}-{}-{}.png'"
+"fits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/test-diff-low-res-{}-{}-{}.fits'"

--- a/snewpdag/data/test-diff-low-res.csv
+++ b/snewpdag/data/test-diff-low-res.csv
@@ -7,5 +7,6 @@
 "Diff-out","Pass","Diff","'line':1, 'dump':1"
 ,,,
 "conf","Chi2CL","Diff","'in_field':'map', 'out_field':'clmap'"
+"conf-out","Pass","conf","'line':1, 'dump':1"
 "skymap","renderers.Mollview","conf","'in_field':'clmap', 'title':'DiffPointing', 'units':'CL', 'min':0, 'max':1, 'coord':['C'], 'filename':'output/test-diff-low-res-{}-{}-{}.png'"
 "fits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/test-diff-low-res-{}-{}-{}.fits'"

--- a/snewpdag/data/test-diff-low-res.csv
+++ b/snewpdag/data/test-diff-low-res.csv
@@ -1,6 +1,6 @@
 "Control","Pass",,"'line': 100"
 ,,,
-"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':-60.0, 'dec':-30.0, 'smear': False, 'time':'2021-11-01 05:22:36.328'"
+"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':60.0, 'dec':-30.0, 'smear': False, 'time':'2021-11-01 05:22:36.328'"
 "Gen-out","Pass","Gen","'line':1, 'dump':1"
 ,,,
 "Diff","DiffPointing","Gen","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
@@ -8,5 +8,5 @@
 ,,,
 "conf","Chi2CL","Diff","'in_field':'map', 'out_field':'clmap'"
 "conf-out","Pass","conf","'line':1, 'dump':1"
-"skymap","renderers.Mollview","conf","'in_field':'clmap', 'title':'DiffPointing', 'units':'CL', 'min':0, 'max':1, 'coord':['C'], 'filename':'output/test-diff-low-res-{}-{}-{}.png'"
+"skymap","renderers.Mollview","conf","'in_field':'clmap', 'title':'DiffPointing', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/test-diff-low-res-{}-{}-{}.png'"
 "fits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/test-diff-low-res-{}-{}-{}.fits'"

--- a/snewpdag/data/test-diff-smear.csv
+++ b/snewpdag/data/test-diff-smear.csv
@@ -1,0 +1,13 @@
+"Control","Pass",,"'line': 100"
+,,,
+"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':-60.0, 'dec':-30.0, 'smear': True, 'time':'2021-11-01 05:22:36.328'"
+,,,"Gen-out","Pass","Gen","'line':1, 'dump':1"
+,,,
+"Diff","DiffPointing","Gen","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
+,,,"Diff-out","Pass","Diff","'line':1, 'dump':1"
+,,,
+"Count","HistogramSkymap","Diff","'nside':8, 'in_field':'map_zeroes', 'out_field':'hist', 'out_err_field':'histerr'"
+"Count-out","Pass","Count","'line':1, 'dump':1"
+,,,
+"skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'DiffPointing Smeared', 'units':'CL', 'min':0, 'max':1, 'coord':['C'], 'filename':'output/test-diff-smear-{}-{}-{}.png'"
+"fits","renderers.FitsSkymap","Count","'in_field':'clmap', 'filename':'output/test-diff-smear-{}-{}-{}.fits'"

--- a/snewpdag/data/test-diff-smear.csv
+++ b/snewpdag/data/test-diff-smear.csv
@@ -1,6 +1,6 @@
 "Control","Pass",,"'line': 100"
 ,,,
-"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':-60.0, 'dec':-30.0, 'smear': True, 'time':'2021-11-01 05:22:36.328'"
+"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':60.0, 'dec':-30.0, 'smear': True, 'time':'2021-11-01 05:22:36.328'"
 ,,,"Gen-out","Pass","Gen","'line':1, 'dump':1"
 ,,,
 "Diff","DiffPointing","Gen","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
@@ -9,5 +9,5 @@
 "Count","HistogramSkymap","Diff","'nside':8, 'in_field':'map_zeroes', 'out_field':'hist', 'out_err_field':'histerr'"
 "Count-out","Pass","Count","'line':1, 'dump':1"
 ,,,
-"skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'DiffPointing Smeared', 'units':'CL', 'min':0, 'max':1, 'coord':['C'], 'filename':'output/test-diff-smear-{}-{}-{}.png'"
-"fits","renderers.FitsSkymap","Count","'in_field':'clmap', 'filename':'output/test-diff-smear-{}-{}-{}.fits'"
+"skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'DiffPointing Smeared', 'units':'Counts', 'range':(0,), 'coord':['C'], 'filename':'output/test-diff-smear-{}-{}-{}.png'"
+,,,"fits","renderers.FitsSkymap","Count","'in_field':'clmap', 'filename':'output/test-diff-smear-{}-{}-{}.fits'"

--- a/snewpdag/data/test-diff.csv
+++ b/snewpdag/data/test-diff.csv
@@ -1,11 +1,11 @@
 "Control","Pass",,"'line': 100"
 ,,,
-"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':-60.0, 'dec':-30.0, 'smear': False, 'time':'2021-11-01 05:22:36.328'"
+"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':0.0, 'dec':-30.0, 'smear': False, 'time':'2021-11-01 05:22:36.328'"
 "Gen-out","Pass","Gen","'line':1, 'dump':1"
 ,,,
 "Diff","DiffPointing","Gen","'detector_location':'snewpdag/data/detector_location.csv', 'nside':32, 'min_dts':3"
 "Diff-out","Pass","Diff","'line':1, 'dump':1"
 ,,,
 "conf","Chi2CL","Diff","'in_field':'map', 'out_field':'clmap'"
-"skymap","renderers.Mollview","conf","'in_field':'clmap', 'title':'DiffPointing', 'units':'CL', 'min':0, 'max':1, 'coord':['C'], 'filename':'output/test-diff-{}-{}-{}.png'"
+"skymap","renderers.Mollview","conf","'in_field':'clmap', 'title':'DiffPointing', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/test-diff-{}-{}-{}.png'"
 "fits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/test-diff-{}-{}-{}.fits'"

--- a/snewpdag/data/test-gen-smear.csv
+++ b/snewpdag/data/test-gen-smear.csv
@@ -1,0 +1,21 @@
+"Control","Pass",,"'line': 100"
+,,,
+"SN","gen.TrueTimes","Control","'detector_location':'snewpdag/data/detector_location.csv', 'detectors': ['SNOP','Borexino','KL','KM3'], 'ra':-60.0, 'dec':-30.0, 'time':'2021-11-01 05:22:36.328'"
+"SN-out","Pass","SN","'line':1, 'dump':1"
+,,,
+"Smear","gen.SmearTimes","SN","'detector_location':'snewpdag/data/detector_location.csv'"
+,,,
+"SNOP-cp","Copy","Smear","'cp':( ('truth/dets/SNOP/neutrino_time', 'neutrino_time'), ('truth/dets/SNOP/bias', 'bias'), ('truth/dets/SNOP/sigma', 'sigma') )"
+"SN-debug","Pass","SNOP-cp","'line':1, 'dump':1"
+"SNOP","Write","SNOP-cp","'write':[ ['detector_name', 'SNOP'] ]"
+,,,
+"Borexino-cp","Copy","Smear","'cp':( ('truth/dets/Borexino/neutrino_time', 'neutrino_time'), ('truth/dets/Borexino/bias', 'bias'), ('truth/dets/Borexino/sigma', 'sigma') )"
+"Borexino","Write","Borexino-cp","'write':[ ['detector_name', 'Borexino'] ]"
+,,,
+"KL-cp","Copy","Smear","'cp':( ('truth/dets/KL/neutrino_time', 'neutrino_time'), ('truth/dets/KL/bias', 'bias'), ('truth/dets/KL/sigma', 'sigma') )"
+"KL","Write","KL-cp","'write':[ ['detector_name', 'KL'] ]"
+,,,
+"KM3-cp","Copy","Smear","'cp':( ('truth/dets/KM3/neutrino_time', 'neutrino_time'), ('truth/dets/KM3/bias', 'bias'), ('truth/dets/KM3/sigma', 'sigma') )"
+"KM3","Write","KM3-cp","'write':[ ['detector_name', 'KM3'] ]"
+,,,
+"Output","Pass","SNOP,Borexino,KL,KM3","'line':1, 'dump':1"

--- a/snewpdag/data/test-pointing-weighted.csv
+++ b/snewpdag/data/test-pointing-weighted.csv
@@ -17,24 +17,25 @@
 "Hires","DiffPointing","Truth","'detector_location':'snewpdag/data/detector_location.csv', 'nside':32, 'min_dts':3"
 "Hires-out","Pass","Hires","'line':1, 'dump':1"
 "Hires-CL","Chi2CL","Hires","'in_field':'map', 'out_field':'clmap'"
-"Hires-skymap","renderers.Mollview","Hires-CL","'in_field':'clmap', 'title':'High resolution truth map', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+"Hires-skymap","renderers.Mollview","Hires-CL","'in_field':'clmap', 'title':'High resolution truth map', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/pw-{}-{}-{}.png'"
 ,,,
 ,,,"low-resolution truth map"
 ,,,
 "Lores","DiffPointing","Truth","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
 "Lores-out","Pass","Lores","'line':1, 'dump':1"
 "Lores-CL","Chi2CL","Lores","'in_field':'map', 'out_field':'clmap'"
-"Lores-skymap","renderers.Mollview","Lores-CL","'in_field':'clmap', 'title':'Low resolution truth map', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+"Lores-skymap","renderers.Mollview","Lores-CL","'in_field':'clmap', 'title':'Low resolution truth map', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/pw-{}-{}-{}.png'"
 ,,,
 ,,,"MC trials processing"
 ,,,
 "Point","DiffPointing","Gen","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
-"Count","HistogramSkymap","Point","'nside':8, 'in_field':'map_zeroes', 'out_field':'hist', 'out_err_field':'histerr'"
-"Count-out","Pass","Count","'line':1, 'dump':1"
-"Count-skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'MC trials', 'units':'Counts', 'range':(0,), 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+"Conf","Chi2CL","Point","'in_field':'map', 'out_field':'clmap'"
+"Norm","NormHistogram","Conf","'in_field':'clmap', 'out_field':'weights'"
+"Accumulate","AccHistogram","Norm","'in_field':'weights', 'out_field':'hist'"
+"Weight-skymap","renderers.Mollview","Accumulate","'on':['report'], 'in_field':'hist', 'title':'Weighted MC trials', 'units':'Weights', 'range':(0,), 'coord':['C'], 'filename':'output/pw-{}-{}-{}.png'"
 ,,,
 ,,,"Comparison of MC trials with low-resolution truth map"
 ,,,
-"Compare","CompareHistograms","Count,Lores-CL","'in_count_field':'hist', 'in_prob_field':'clmap', 'out_field':'diff'"
-"Compare-skymap","renderers.Mollview","Compare","'on':['report'], 'in_field':'diff', 'title':'Comparison counts-pred/err', 'units':'diff/err', 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+"Compare","CompareHistograms","Accumulate,Lores-CL","'in_count_field':'hist', 'in_prob_field':'clmap', 'out_field':'diff'"
+"Compare-skymap","renderers.Mollview","Compare","'on':['report'], 'in_field':'diff', 'title':'Comparison counts-pred/err', 'units':'diff/err', 'coord':['C'], 'filename':'output/pw-{}-{}-{}.png'"
 "Compare-out","Pass","Compare","'line':1, 'dump':1"

--- a/snewpdag/data/test-pointing.csv
+++ b/snewpdag/data/test-pointing.csv
@@ -1,0 +1,40 @@
+"Control","Pass",,"'line': 100"
+,,,
+,,,"MC trials"
+,,,"Change ra/dec in Gen and Truth specifications"
+,,,
+"Gen","gen.GenPoint","Control","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':60.0, 'dec':-30.0, 'smear': True, 'time':'2021-11-01 05:22:36.328'"
+,,,"Gen-out","Pass","Gen","'line':1, 'dump':1"
+,,,
+,,,"unsmeared probability maps - only do for trial_id=0"
+,,,
+"First","FilterValue","Control","'in_field':'trial_id', 'value':0"
+"Truth","gen.GenPoint","First","'detector_location':'snewpdag/data/detector_location.csv', 'pair_list':[('SNOP','Borexino'),('SNOP','KL'),('SNOP','KM3')], 'ra':60.0, 'dec':-30.0, 'smear': False, 'time':'2021-11-01 05:22:36.328'"
+"Truth-out","Pass","Truth","'line':1, 'dump':1"
+,,,
+,,,"high-resolution truth map"
+,,,
+"Hires","DiffPointing","Truth","'detector_location':'snewpdag/data/detector_location.csv', 'nside':32, 'min_dts':3"
+"Hires-out","Pass","Hires","'line':1, 'dump':1"
+"Hires-CL","Chi2CL","Hires","'in_field':'map', 'out_field':'clmap'"
+"Hires-skymap","renderers.Mollview","Hires-CL","'in_field':'clmap', 'title':'High resolution truth map', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+,,,
+,,,"low-resolution truth map"
+,,,
+"Lores","DiffPointing","Truth","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
+"Lores-out","Pass","Lores","'line':1, 'dump':1"
+"Lores-CL","Chi2CL","Lores","'in_field':'map', 'out_field':'clmap'"
+"Lores-skymap","renderers.Mollview","Lores-CL","'in_field':'clmap', 'title':'Low resolution truth map', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+,,,
+,,,"MC trials processing"
+,,,
+"Point","DiffPointing","Gen","'detector_location':'snewpdag/data/detector_location.csv', 'nside':8, 'min_dts':3"
+"Count","HistogramSkymap","Point","'nside':8, 'in_field':'map_zeroes', 'out_field':'hist', 'out_err_field':'histerr'"
+"Count-out","Pass","Count","'line':1, 'dump':1"
+"Count-skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'MC trials', 'units':'Counts', 'range':(0,), 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+,,,
+,,,"Comparison of MC trials with low-resolution truth map"
+,,,
+"Compare","CompareHistogram","Count,Lores-CL","'in_count_field':'hist', 'in_prob_field':'clmap', 'out_field':'diff'"
+"Compare-skymap","renderers.Mollview","Compare","'on':['report'], 'in_field':'diff', 'title':'Comparison counts-pred/err', 'units':'diff/err', 'coord':['C'], 'filename':'output/pointing-{}-{}-{}.png'"
+"Compare-out","Pass","Compare","'line':1, 'dump':1"

--- a/snewpdag/plugins/AccHistogram.py
+++ b/snewpdag/plugins/AccHistogram.py
@@ -1,0 +1,40 @@
+"""
+AccHistogram - accumulate histogram
+
+Arguments:
+  in_field: name of input field to accumulate
+  out_field: name of output field on report
+
+Input payload:
+  in_field: histogram to add.
+  Consumes alert.
+
+Output payload (report only):
+  out_field: normalized histogram
+"""
+import logging
+import numpy as np
+
+from snewpdag.dag import Node
+
+class AccHistogram(Node):
+  def __init__(self, in_field, out_field, **kwargs):
+    self.m = np.array([])
+    self.in_field = in_field
+    self.out_field = out_field
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    if self.in_field in data:
+      if len(self.m) == 0:
+        self.m = np.zeros(len(data[self.in_field]))
+      elif len(data[self.in_field]) != len(self.m):
+        logging.warning('{}: unequal histogram sizes'.format(self.name))
+        return False
+      self.m += data[self.in_field]
+    return False
+
+  def report(self, data):
+    data[self.out_field] = self.m
+    return data
+

--- a/snewpdag/plugins/CompareHistogram.py
+++ b/snewpdag/plugins/CompareHistogram.py
@@ -1,0 +1,49 @@
+"""
+CompareHistogram - compare count vs a probability map
+"""
+import logging
+import numpy as np
+
+from snewpdag.dag import Node
+
+class CompareHistogram(Node):
+  def __init__(self, in_count_field, in_prob_field, out_field, **kwargs):
+    self.in_count_field = in_count_field
+    self.in_prob_field = in_prob_field
+    self.out_field = out_field
+    self.prob = np.array([]) # null array
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    logging.debug('{}: alert'.format(self.name))
+    # probability map may come in on alert or report
+    if self.in_prob_field in data:
+      logging.debug('{}: probability map registered'.format(self.name))
+      self.prob = np.array(data[self.in_prob_field], copy=True)
+    return False # count map will come with report
+
+  def report(self, data):
+    logging.debug('{}: report'.format(self.name))
+    # probability map may come in on alert or report
+    if self.in_prob_field in data:
+      self.prob = np.array(data[self.in_prob_field], copy=True)
+    if len(self.prob) == 0:
+      logging.debug('{}: no probability map'.format(self.name))
+      return False
+    if self.in_count_field in data:
+      logging.debug('{}: histogram map registered'.format(self.name))
+      hist = np.array(data[self.in_count_field])
+    else:
+      logging.debug('{}: no histogram map'.format(self.name))
+      return False
+    # normalize probability map to agree in overall counts
+    factor = hist.sum() / self.prob.sum()
+    pred = self.prob * factor
+    # errors:  take max of pred or count (may still be 0)
+    err = np.sqrt(np.maximum(pred, hist))
+    # comparison - nan if 0 in both counts and prediction
+    chi = (hist - pred) / err
+    data[self.out_field] = chi
+    logging.debug('{}: success!'.format(self.name))
+    return data
+

--- a/snewpdag/plugins/CompareHistograms.py
+++ b/snewpdag/plugins/CompareHistograms.py
@@ -1,12 +1,28 @@
 """
-CompareHistogram - compare count vs a probability map
+CompareHistograms - compare count vs a probability map
+
+Arguments:
+  in_count_field: name of field containing histogram of event counts
+  in_prob_field: name of field containing probability map
+  out_field: field to contain diff/err
+
+Input payload (alert):
+  in_prob_field: probability map
+  Consumes alert.
+
+Input payload (report):
+  in_count_field: histogram of event counts
+  in_prob_field (optional): probability map
+
+Output payload (report only):
+  out_field: diff/err map
 """
 import logging
 import numpy as np
 
 from snewpdag.dag import Node
 
-class CompareHistogram(Node):
+class CompareHistograms(Node):
   def __init__(self, in_count_field, in_prob_field, out_field, **kwargs):
     self.in_count_field = in_count_field
     self.in_prob_field = in_prob_field

--- a/snewpdag/plugins/Copy.py
+++ b/snewpdag/plugins/Copy.py
@@ -1,0 +1,54 @@
+"""
+Copy - copy fields into other (possibly new) fields
+
+configuration:
+  on: list of 'alert', 'revoke', 'report', 'reset' (optional: def 'alert' only)
+  cp: ( (in,out), ... )
+
+Field names take the form of dir1/dir2/dir3,
+which in the payload will be data[dir1][dir2][dir3]
+"""
+import logging
+
+from snewpdag.dag import Node
+
+class Copy(Node):
+  def __init__(self, cp, **kwargs):
+    self.cp = []
+    for op in cp:
+      src = op[0].split('/')
+      dst = op[1].split('/')
+      self.cp.append( [src, dst[:-1], dst[-1]] )
+    self.on = kwargs.pop('on', [ 'alert' ])
+    super().__init__(**kwargs)
+
+  def copy(self, data):
+    for op in self.cp:
+      v = data # should just follow references
+      for k in op[0]:
+        if k in v:
+          v = v[k]
+        else:
+          logging.warning('Field {} not found from source {}'.format(k, op[0]))
+          continue
+      # v should now hold the value to be copied
+      d = data
+      for k in op[1]:
+        if k not in d:
+          d[k] = {}
+        d = d[k]
+      d[op[2]] = v
+    return data
+
+  def alert(self, data):
+    return self.copy(data) if 'alert' in self.on else True
+
+  def revoke(self, data):
+    return self.copy(data) if 'revoke' in self.on else True
+
+  def reset(self, data):
+    return self.copy(data) if 'reset' in self.on else True
+
+  def report(self, data):
+    return self.copy(data) if 'report' in self.on else True
+

--- a/snewpdag/plugins/DiffPointing.py
+++ b/snewpdag/plugins/DiffPointing.py
@@ -152,6 +152,7 @@ class DiffPointing(Node):
     m -= chi2_min
     data['map'] = m
     data['ndof'] = 2
+    data['map_zeroes'] = np.where(m == 0.0)
     return data
 
   def alert(self, data):

--- a/snewpdag/plugins/HistogramSkymap.py
+++ b/snewpdag/plugins/HistogramSkymap.py
@@ -1,0 +1,51 @@
+"""
+HistogramSkymap - keep counts in a skymap
+
+Arguments:
+  nside: skymap healpix resolution
+  in_field: name of input field containing indices to increment
+  out_field: name of map output field
+  out_err_field: name of map output field containing stddevs
+
+Input payload:
+  in_field: indices to increment within skymap
+
+Output payload (report only):
+  out_field: healpix skymap, norm such that max value is 1 (or 0 if all zero)
+"""
+import logging
+import numpy as np
+import healpy as hp
+
+from snewpdag.dag import Node
+
+class HistogramSkymap(Node):
+  def __init__(self, nside, in_field, out_field, out_err_field, **kwargs):
+    self.in_field = in_field
+    self.out_field = out_field
+    self.out_err_field = out_err_field
+    self.m = np.zeros(hp.nside2npix(nside))
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    self.m[data[self.in_field]] += 1
+    return False
+
+  def reset(self, data):
+    return False
+
+  def revoke(self, data):
+    return False
+
+  def report(self, data):
+    maxv = np.amax(self.m)
+    if maxv > 0:
+      mm = self.m / maxv
+      me = np.sqrt(self.m) / maxv
+    else:
+      mm = self.m
+      me = mm
+    data[self.out_field] = mm
+    data[self.out_err_field] = me
+    return data
+

--- a/snewpdag/plugins/NormHistogram.py
+++ b/snewpdag/plugins/NormHistogram.py
@@ -1,0 +1,34 @@
+"""
+NormHistogram - normalize histogram to some area
+
+Arguments:
+  in_field: name of input field to normalize
+  out_field: name of output field, after normalization
+  area: (optional) area to normalize to
+
+Input payload:
+  in_field: histogram to normalize
+
+Output payload:
+  out_field: normalized histogram
+"""
+import logging
+import numpy as np
+
+from snewpdag.dag import Node
+
+class NormHistogram(Node):
+  def __init__(self, in_field, out_field, **kwargs):
+    self.area = kwargs.pop('area', 1.0)
+    self.in_field = in_field
+    self.out_field = out_field
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    if self.in_field in data:
+      m = np.array(data[self.in_field])
+      data[self.out_field] = m * self.area / np.sum(m)
+      return data
+    else:
+      return False
+

--- a/snewpdag/plugins/Pass.py
+++ b/snewpdag/plugins/Pass.py
@@ -14,14 +14,8 @@ from snewpdag.dag import Node
 
 class Pass(Node):
   def __init__(self, **kwargs):
-    self.line = 100
-    self.dump = 0
-    if 'line' in kwargs:
-      self.line = kwargs['line']
-      kwargs.pop('line')
-    if 'dump' in kwargs:
-      self.dump = kwargs['dump']
-      kwargs.pop('dump')
+    self.line = kwargs.pop('line', 100)
+    self.dump = kwargs.pop('dump', 0)
     self.count = 0
     super().__init__(**kwargs)
 
@@ -31,10 +25,11 @@ class Pass(Node):
         print('{0}{1}:'.format(indent, k))
         self.print_dict(indent + '  ', v)
       else:
-        print('{0}{1}: {2}'.format(indent, k, v))
+        print('{0}{1}: {2}'.format(indent, k, repr(v)))
 
   def alert(self, data):
     self.count += 1
+    logging.debug('{}: alert'.format(self.name))
     if self.line > 0:
       if self.count == 1 or self.count % self.line == 0:
         print('{0}: received {1} alerts'.format(self.name, self.count))
@@ -46,6 +41,7 @@ class Pass(Node):
     return True
 
   def revoke(self, data):
+    logging.debug('{}: revoke'.format(self.name))
     if self.dump > 0:
       print('>>>> {0} >>>> ({1}) revoke'.format(self.name, self.count))
       self.print_dict('', data)
@@ -53,12 +49,14 @@ class Pass(Node):
     return True
 
   def report(self, data):
+    logging.debug('{}: report'.format(self.name))
     print('>>>> {0} >>>> ({1}) report'.format(self.name, self.count))
     self.print_dict('', data)
     print('<<<< {} <<<<'.format(self.name))
     return True
 
   def reset(self, data):
+    logging.debug('{}: reset'.format(self.name))
     if self.dump > 0:
       print('>>>> {0} >>>> ({1}) reset'.format(self.name, self.count))
       self.print_dict('', data)

--- a/snewpdag/plugins/Write.py
+++ b/snewpdag/plugins/Write.py
@@ -1,0 +1,45 @@
+"""
+Write - write fields into the payload
+
+configuration:
+  on: list of 'alert', 'revoke', 'report', 'reset' (optional: def 'alert' only)
+  write: ( (field,value), ... )
+
+Field names take the form of dir1/dir2/dir3,
+which in the payload will be data[dir1][dir2][dir3]
+"""
+import logging
+
+from snewpdag.dag import Node
+
+class Write(Node):
+  def __init__(self, write, **kwargs):
+    self.writes = []
+    for op in write:
+      dst = op[0].split('/')
+      self.writes.append( [dst[:-1], dst[-1], op[1]] )
+    self.on = kwargs.pop('on', [ 'alert' ])
+    super().__init__(**kwargs)
+
+  def ops(self, data):
+    for op in self.writes:
+      d = data
+      for k in op[0]:
+        if k not in d:
+          d[k] = {}
+        d = d[k]
+      d[op[1]] = op[2]
+    return data
+
+  def alert(self, data):
+    return self.ops(data) if 'alert' in self.on else True
+
+  def revoke(self, data):
+    return self.ops(data) if 'revoke' in self.on else True
+
+  def reset(self, data):
+    return self.ops(data) if 'reset' in self.on else True
+
+  def report(self, data):
+    return self.ops(data) if 'report' in self.on else True
+

--- a/snewpdag/plugins/__init__.py
+++ b/snewpdag/plugins/__init__.py
@@ -1,4 +1,6 @@
 from .Pass import Pass
+from .Copy import Copy
+from .Write import Write
 
 from .TimeSeriesInput import TimeSeriesInput
 from .TimeDistInput import TimeDistInput
@@ -15,6 +17,7 @@ from .BayesianBlocks import BayesianBlocks
 
 from .Histogram1D import Histogram1D
 from .Histogram1DRebin import Histogram1DRebin
+from .HistogramSkymap import HistogramSkymap
 from .Accumulator import Accumulator
 
 from .SeriesBinner import SeriesBinner

--- a/snewpdag/plugins/__init__.py
+++ b/snewpdag/plugins/__init__.py
@@ -19,6 +19,7 @@ from .Histogram1D import Histogram1D
 from .Histogram1DRebin import Histogram1DRebin
 from .HistogramSkymap import HistogramSkymap
 from .Accumulator import Accumulator
+from .CompareHistogram import CompareHistogram
 
 from .SeriesBinner import SeriesBinner
 from .BinnedAccumulator import BinnedAccumulator
@@ -35,6 +36,7 @@ from .ValidateKey import ValidateKey
 from .ValidateKeyType import ValidateKeyType
 from .ValidateListType import ValidateListType
 from .ValidateSort import ValidateSort
+from .FilterValue import FilterValue
 
 from .TrueVsFit import TrueVsFit
 

--- a/snewpdag/plugins/__init__.py
+++ b/snewpdag/plugins/__init__.py
@@ -19,7 +19,9 @@ from .Histogram1D import Histogram1D
 from .Histogram1DRebin import Histogram1DRebin
 from .HistogramSkymap import HistogramSkymap
 from .Accumulator import Accumulator
-from .CompareHistogram import CompareHistogram
+from .CompareHistograms import CompareHistograms
+from .NormHistogram import NormHistogram
+from .AccHistogram import AccHistogram
 
 from .SeriesBinner import SeriesBinner
 from .BinnedAccumulator import BinnedAccumulator

--- a/snewpdag/plugins/gen/GenPoint.py
+++ b/snewpdag/plugins/gen/GenPoint.py
@@ -1,5 +1,24 @@
 """
 GenPoint - generate time differences for a given SN direction
+
+Arguments:
+  detector_location: filename of detector database for DetectorDB
+  detectors: list of detectors for which to generate burst times
+  ra: right ascension (degrees)
+  dec: declination (degrees)
+  time: time string, e.g., '2021-11-01 05:22:36.328'
+  smear: (optional, default True) whether to smear output times
+
+Output:
+  truth/sn_ra: right ascension (radians)
+  truth/sn_dec: declination (radians)
+  dts/(<det1>,<det2>)/dt: time difference between detectors (s, ns)
+  dts/(<det1>,<det2>)/t1: arrival time for det1 (s, ns)
+  dts/(<det1>,<det2>)/t2: arrival time for det2 (s, ns)
+  dts/(<det1>,<det2>)/bias: bias1 - bias2 (sec)
+  dts/(<det1>,<det2>)/var: combined variance (sec^2)
+  dts/(<det1>,<det2>)/dsig1: sigma1 (sec)
+  dts/(<det1>,<det2>)/dsig2: -sigma2 (sec)
 """
 import logging
 import numpy as np

--- a/snewpdag/plugins/gen/SmearTimes.py
+++ b/snewpdag/plugins/gen/SmearTimes.py
@@ -1,5 +1,16 @@
 """
 SmearTimes - smear true times
+
+Arguments:
+  detector_location: filename of detector database for DetectorDB
+
+Input:
+  truth/dets/<det_id>/true_t: arrival time (s, ns), s in unix time
+
+Output:
+  truth/dets/det_id>/neutrino_time: smeared time (s, ns)
+  truth/dets/bias: bias (s), from db
+  truth/dets/sigma: sigma (s), from db
 """
 import logging
 import numpy as np

--- a/snewpdag/plugins/gen/SmearTimes.py
+++ b/snewpdag/plugins/gen/SmearTimes.py
@@ -1,0 +1,35 @@
+"""
+SmearTimes - smear true times
+"""
+import logging
+import numpy as np
+import healpy as hp
+from astropy.time import Time
+from astropy import constants as const
+from astropy import units as u
+
+from snewpdag.dag import Node, Detector, DetectorDB
+from snewpdag.dag.lib import normalize_time, subtract_time
+
+class SmearTimes(Node):
+  def __init__(self, detector_location, **kwargs):
+    self.db = DetectorDB(detector_location)
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    g = 1000000000 / u.second
+    logging.info('truth/dets = {}'.format(data['truth']['dets']))
+    for k in data['truth']['dets'].keys():
+      #c = 3.0e8 # m/s
+      det = self.db.get(k)
+      v = data['truth']['dets'][k]
+      logging.info('k = {}, v = {}'.format(k, v))
+      t0 = v['true_t'] # (s, ns)
+      dt = det.bias * u.second # bias (s)
+      dt += det.sigma * Node.rng.normal() * u.second # smear (s)
+      dtt = (t0[0], t0[1] + dt * g)
+      v['neutrino_time'] = normalize_time(dtt)
+      v['bias'] = det.bias
+      v['sigma'] = det.sigma
+    return data
+

--- a/snewpdag/plugins/gen/TrueTimes.py
+++ b/snewpdag/plugins/gen/TrueTimes.py
@@ -1,5 +1,17 @@
 """
-TrueTimes - generate true times
+TrueTimes - generate true arrival times
+
+Arguments:
+  detector_location: filename of detector database for DetectorDB
+  detectors: list of detectors for which to generate burst times
+  ra: right ascension (degrees)
+  dec: declination (degrees)
+  time: time string, e.g., '2021-11-01 05:22:36.328'
+
+Output:
+  truth/true_sn_ra: right ascension (radians)
+  truth/true_sn_dec: declination (radians)
+  truth/dets/<det_id>/true_t: arrival time (s, ns), s in unix time
 """
 import logging
 import numpy as np

--- a/snewpdag/plugins/gen/TrueTimes.py
+++ b/snewpdag/plugins/gen/TrueTimes.py
@@ -1,0 +1,58 @@
+"""
+TrueTimes - generate true times
+"""
+import logging
+import numpy as np
+import healpy as hp
+from astropy.time import Time
+from astropy import constants as const
+from astropy import units as u
+
+from snewpdag.dag import Node, Detector, DetectorDB
+from snewpdag.dag.lib import normalize_time
+
+class TrueTimes(Node):
+  def __init__(self, detector_location, detectors, ra, dec, time, **kwargs):
+    self.db = DetectorDB(detector_location)
+    self.ra = np.radians(ra)
+    self.dec = np.radians(dec)
+    self.time = Time(time)
+    t = self.time.to_value('unix', 'long')
+    ti = int(t)
+    tf = t - ti
+    g = 1000000000
+    self.ttuple = (ti, int(tf * g))
+    self.snr = np.array([ np.cos(self.dec)*np.cos(self.ra),
+                          np.cos(self.dec)*np.sin(self.ra),
+                          np.sin(self.dec) ])
+    logging.info('ra(lon) = {}, dec(lat) = {}'.format(self.ra, self.dec))
+    logging.info('SN location = {}'.format(self.snr))
+    self.dets = set(detectors)
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    # record truth information
+    if 'truth' not in data:
+      data['truth'] = {}
+    data['truth']['true_sn_ra'] = self.ra # radians
+    data['truth']['true_sn_dec'] = self.dec # radians
+
+    # generate true times for each detector.
+    # given time is when wavefront arrives at Earth origin.
+    g = 1000000000 / u.second
+    ts = {}
+    for dname in self.dets:
+      #c = 3.0e8 # m/s
+      det = self.db.get(dname)
+      pos = det.get_xyz(self.time)
+      logging.info('pos[{}] = {}'.format(dname, pos))
+      logging.info('  sn pos = {}'.format(self.snr))
+      dt = - np.dot(det.get_xyz(self.time), self.snr) / const.c # intersect
+      dtt = (self.ttuple[0], self.ttuple[1] + dt * g)
+      ts[dname] = {
+                    'true_t': normalize_time(dtt), # (s, ns)
+                  }
+
+    data['truth']['dets'] = ts
+    return data
+

--- a/snewpdag/plugins/gen/__init__.py
+++ b/snewpdag/plugins/gen/__init__.py
@@ -14,3 +14,6 @@ from .DetectorTime import DetectorTime
 
 from .GenPoint import GenPoint
 
+from .TrueTimes import TrueTimes
+from .SmearTimes import SmearTimes
+

--- a/snewpdag/plugins/renderers/Mollview.py
+++ b/snewpdag/plugins/renderers/Mollview.py
@@ -1,5 +1,15 @@
 """
-Mollview
+Mollview - primitive skymap image
+
+Arguments:
+  in_field: payload field name for skymap
+  title: title to put on image
+  units: unit label text
+  coord: 'C' celestial, 'E' ecliptic, 'G' galactic; list of conversion
+  filename: output filename, {0} module name, {1} count, {2} burst_id
+  min: minimum value (default 0)
+  max: maximum value (default 1)
+  on: list of 'alert', 'reset', 'revoke', 'report' (default ['alert'])
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,12 +25,13 @@ class Mollview(Node):
     self.units = units
     self.coord = coord
     self.filename = filename
-    self.min = kwargs.pop('min', 1)
+    self.min = kwargs.pop('min', 0)
     self.max = kwargs.pop('max', 1)
+    self.on = kwargs.pop('on', ['alert'])
     self.count = 0
     super().__init__(**kwargs)
 
-  def alert(self, data):
+  def plot(self, data):
     burst_id = data.get('burst_id', 0)
     if self.in_field in data:
       m = data[self.in_field]
@@ -38,4 +49,16 @@ class Mollview(Node):
       plt.savefig(fname)
       self.count += 1
     return True
+
+  def alert(self, data):
+    return self.plot(data) if 'alert' in self.on else True
+
+  def revoke(self, data):
+    return self.plot(data) if 'revoke' in self.on else True
+
+  def reset(self, data):
+    return self.plot(data) if 'reset' in self.on else True
+
+  def report(self, data):
+    return self.plot(data) if 'report' in self.on else True
 

--- a/snewpdag/plugins/renderers/Mollview.py
+++ b/snewpdag/plugins/renderers/Mollview.py
@@ -7,10 +7,12 @@ Arguments:
   units: unit label text
   coord: 'C' celestial, 'E' ecliptic, 'G' galactic; list of conversion
   filename: output filename, {0} module name, {1} count, {2} burst_id
+  range: (optional, default none), none, (min,) or (min,max)
   min: minimum value (default 0)
-  max: maximum value (default 1)
+  max: maximum value (default -1). If max <= min, get max from data
   on: list of 'alert', 'reset', 'revoke', 'report' (default ['alert'])
 """
+import logging
 import matplotlib.pyplot as plt
 import numpy as np
 import healpy as hp
@@ -25,8 +27,9 @@ class Mollview(Node):
     self.units = units
     self.coord = coord
     self.filename = filename
-    self.min = kwargs.pop('min', 0)
-    self.max = kwargs.pop('max', 1)
+    self.range = kwargs.pop('range', None)
+    #self.min = kwargs.pop('min', 0)
+    #self.max = kwargs.pop('max', -1)
     self.on = kwargs.pop('on', ['alert'])
     self.count = 0
     super().__init__(**kwargs)
@@ -36,13 +39,20 @@ class Mollview(Node):
     if self.in_field in data:
       m = data[self.in_field]
       # replace a lot of these options later
+      kwargs = {}
+      if isinstance(self.range, (list, tuple, np.ndarray)):
+        if len(self.range) >= 1:
+          kwargs['min'] = self.range[0]
+        if len(self.range) >= 2:
+          kwargs['max'] = self.range[1]
       hp.mollview(m,
                   coord=self.coord,
                   title=self.title,
                   unit=self.units,
-                  min=self.min,
-                  max=self.max,
+                  #min=self.min,
+                  #max=self.max,
                   nest=True,
+                  **kwargs,
                  )
       hp.graticule()
       fname = self.filename.format(self.name, self.count, burst_id)
@@ -51,14 +61,18 @@ class Mollview(Node):
     return True
 
   def alert(self, data):
+    logging.debug('{}: alert'.format(self.name))
     return self.plot(data) if 'alert' in self.on else True
 
   def revoke(self, data):
+    logging.debug('{}: revoke'.format(self.name))
     return self.plot(data) if 'revoke' in self.on else True
 
   def reset(self, data):
+    logging.debug('{}: reset'.format(self.name))
     return self.plot(data) if 'reset' in self.on else True
 
   def report(self, data):
+    logging.debug('{}: report'.format(self.name))
     return self.plot(data) if 'report' in self.on else True
 

--- a/snewpdag/tests/test_copy.py
+++ b/snewpdag/tests/test_copy.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for Copy plugin
+"""
+import unittest
+
+from snewpdag.plugins import Copy
+
+class TestCopy(unittest.TestCase):
+
+  def test_copy_single(self):
+    h = Copy([ ['gen/t', 'neutrino_time'] ], name='copy0')
+    data = { 'action': 'alert', 'gen' : { 't': 0.5 } }
+    ret = h.alert(data)
+    self.assertEqual(data['neutrino_time'], 0.5)
+
+    h = Copy([ ['source', 'dest'] ], name='copy1')
+    data = { 'action': 'alert', 'source' : 1.0 }
+    ret = h.alert(data)
+    self.assertEqual(data['dest'], 1.0)
+
+    h = Copy([ ['source', 'dest/value'] ], name='copy2')
+    data = { 'action': 'alert', 'source' : 1.0 }
+    ret = h.alert(data)
+    self.assertEqual(data['dest']['value'], 1.0)
+
+  def test_copy_multiple(self):
+    h = Copy([ ['gen/t', 'neutrino_time'], ['gen/x', 'dest/x' ] ],
+             name='copy0')
+    data = { 'action': 'alert', 'gen' : { 't': 0.5, 'x': 0.25 } }
+    ret = h.alert(data)
+    self.assertEqual(data['neutrino_time'], 0.5)
+    self.assertEqual(data['dest']['x'], 0.25)
+


### PR DESCRIPTION
Several additions to facilitate MC trials and move in direction of making MC look like alert data:
1. plugin utilities Copy and Write, for directly manipulating payload without having to write specific new plugins.
2. take apart GenPoint to generate true arrival times (TrueTimes) and resolution/bias smearing (SmearTimes).
3. HistogramSkymap to count most likely directions given a chi2 map from DiffPointing.
4. test-gen-smear.csv uses TrueTimes/SmearTimes to generate arrival times for 4 detectors, adding information we expect if the alerts are transmitted together as a coincidence.
5. test-diff-smear.csv generates 10k trials and counts most likely directions in HistogramSkymap.
6. test-diff-low-res.csv is similar to older test-diff.csv, but with nside=8 so it can be compared with test-diff-smear.csv output.

Change (4) should be able to feed a delta-time calculator; this would then deprecate gen.GenPoint.
