### PR TITLE
Pickle input and output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ trial2:
 	python snewpdag/trials/Simple.py Control -n 10 | \
           python -m snewpdag --log INFO --jsonlines snewpdag/data/test-liq-config.py
 
+pickle_output:
+	python snewpdag/trials/Simple.py Control -n 10 | \
+          python -m snewpdag --log INFO --jsonlines snewpdag/data/test-pickle-out.py
+
+pickle_input:
+	python snewpdag/trials/Simple.py Control -n 1 | \
+          python -m snewpdag --log INFO --jsonlines snewpdag/data/test-pickle-in.py
+
 diffpointing:
 	python snewpdag/trials/Simple.py Control -n 1 | \
           python -m snewpdag --log INFO --jsonlines snewpdag/data/test-diff.csv

--- a/snewpdag/data/test-pickle-in.py
+++ b/snewpdag/data/test-pickle-in.py
@@ -10,7 +10,7 @@
     "class": "PickleInput",
     "observe": [ "Control" ],
     "kwargs": {
-      "filename": "output/pickle-pickle-0-0.pickle",
+      "filename": "output/test-pickle-0-0.pickle",
     },
   },
 

--- a/snewpdag/data/test-pickle-in.py
+++ b/snewpdag/data/test-pickle-in.py
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "Control",
+    "class": "Pass",
+    "kwargs": { "line": 100 },
+  },
+
+  {
+    "name": "pickle-in",
+    "class": "PickleInput",
+    "observe": [ "Control" ],
+    "kwargs": {
+      "filename": "output/pickle-pickle-0-0.pickle",
+    },
+  },
+
+  {
+    "name": "Dump",
+    "class": "Pass",
+    "observe": [ "pickle-in" ],
+    "kwargs": { "line": 1, "dump": 1 }
+  },
+
+  {
+    "name": "Diff-dt-h",
+    "class": "renderers.Histogram1D",
+    "observe": [ "pickle-in" ],
+    "kwargs": {
+      "title": "Time difference",
+      "xlabel": "dt [s]",
+      "ylabel": "entries/0.1s",
+      "filename": "output/redo-{}-{}-{}.png"
+    }
+  },
+
+]

--- a/snewpdag/data/test-pickle-out.py
+++ b/snewpdag/data/test-pickle-out.py
@@ -52,7 +52,7 @@
       "title": "JUNO time profile",
       "xlabel": "time [s]",
       "ylabel": "entries/0.1s",
-      "filename": "output/gen-liq-{}-{}-{}.png"
+      "filename": "output/test-{}-{}-{}.png"
     }
   },
 
@@ -99,7 +99,7 @@
       "title": "SNOP time profile",
       "xlabel": "time [s]",
       "ylabel": "entries/0.1s",
-      "filename": "output/gen-liq-{}-{}-{}.png"
+      "filename": "output/test-{}-{}-{}.png"
     }
   },
 
@@ -138,16 +138,16 @@
       "title": "Time difference",
       "xlabel": "dt [s]",
       "ylabel": "entries/0.1s",
-      "filename": "output/gen-liq-{}-{}-{}.png"
+      "filename": "output/test-{}-{}-{}.png"
     }
   },
 
   {
     "name": "pickle",
-    "class": "renderers.PicklePayload",
+    "class": "renderers.PickleOutput",
     "observe": [ "Diff-dt" ],
     "kwargs": {
-      "filename": "output/pickle-{}-{}-{}.pickle"
+      "filename": "output/test-{}-{}-{}.pickle"
     }
   },
 

--- a/snewpdag/data/test-pickle-out.py
+++ b/snewpdag/data/test-pickle-out.py
@@ -1,0 +1,156 @@
+#
+# a test DAG for generating and analyzing two experiment alerts
+#
+
+[
+  {
+    "name": "Control", "class": "Pass",
+    "kwargs": { "line": 100 }
+  },
+
+  {
+    "name": "JUNO-ts", "class": "gen.TimeSeries",
+    "observe": [ "Control" ],
+    "kwargs": {
+      "mean": 1000,
+      "detector": "JUNO",
+      "sig_filetype": "tn", "sig_filename":
+      "snewpdag/data/output_scint20kt_27_Shen_1D_solar_mass_progenitor.fits_1msbin.txt"
+    }
+  },
+
+  { "name": "JUNO", "class": "gen.Combine", "observe": [ "JUNO-ts" ] },
+
+  {
+    "name": "JUNO-out", "class": "Pass",
+    "observe": [ "JUNO" ],
+    "kwargs": { "line": 1, "dump": 1 }
+  },
+
+  {
+    "name": "JUNO-bin", "class": "BinnedAccumulator",
+    "observe": [ "JUNO" ],
+    "kwargs": {
+      "in_field": "times",
+      "nbins": 2000, "xlow": -10.0, "xhigh": 10.0,
+      "out_xfield": "t", "out_yfield": "bins",
+      'flags': [ 'overflow' ],
+    }
+  },
+
+  {
+    "name": "JUNO-bin-out", "class": "Pass",
+    "observe": [ "JUNO-bin" ],
+    "kwargs": { "line": 1, "dump": 1 }
+  },
+
+  {
+    "name": "JUNO-bin-h",
+    "class": "renderers.Histogram1D",
+    "observe": [ "JUNO-bin" ],
+    "kwargs": {
+      "title": "JUNO time profile",
+      "xlabel": "time [s]",
+      "ylabel": "entries/0.1s",
+      "filename": "output/gen-liq-{}-{}-{}.png"
+    }
+  },
+
+  {
+    "name": "SNOP-ts", "class": "gen.TimeSeries",
+    "observe": [ "Control" ],
+    "kwargs": {
+      "mean": 100,
+      "detector": "SNOP",
+      "sig_filetype": "tn", "sig_filename":
+      "snewpdag/data/output_scint20kt_27_Shen_1D_solar_mass_progenitor.fits_1msbin.txt"
+    }
+  },
+
+  { "name": "SNOP", "class": "gen.Combine", "observe": [ "SNOP-ts" ] },
+
+  {
+    "name": "SNOP-out", "class": "Pass",
+    "observe": [ "SNOP" ],
+    "kwargs": { "line": 1, "dump": 1 }
+  },
+
+  {
+    "name": "SNOP-bin", "class": "BinnedAccumulator",
+    "observe": [ "SNOP" ],
+    "kwargs": {
+      "in_field": "times",
+      "nbins": 2000, "xlow": -10.0, "xhigh": 10.0,
+      "out_xfield": "t", "out_yfield": "bins",
+      'flags': [ 'overflow' ],
+    }
+  },
+
+  {
+    "name": "SNOP-bin-out", "class": "Pass",
+    "observe": [ "SNOP-bin" ],
+    "kwargs": { "line": 1, "dump": 1 }
+  },
+
+  {
+    "name": "SNOP-bin-h", "class": "renderers.Histogram1D",
+    "observe": [ "SNOP-bin" ],
+    "kwargs": {
+      "title": "SNOP time profile",
+      "xlabel": "time [s]",
+      "ylabel": "entries/0.1s",
+      "filename": "output/gen-liq-{}-{}-{}.png"
+    }
+  },
+
+  {
+    "name": "Diff", "class": "NthTimeDiff",
+    "observe": [ "JUNO", "SNOP" ],
+    "kwargs": { "nth": 1 }
+  },
+
+  {
+    "name": "Diff-out", "class": "Pass",
+    "observe": [ "Diff" ],
+    "kwargs": { "line": 100, "dump": 1 }
+  },
+
+  {
+    "name": "Diff-dt", "class": "Histogram1D",
+    "observe": [ "Diff" ],
+    "kwargs": {
+      "in_field": "dt",
+      "nbins": 100, "xlow": -0.1, "xhigh": 0.1,
+    }
+  },
+
+  {
+    "name": "Diff-dt-out", "class": "Pass",
+    "observe": [ "Diff-dt" ],
+    "kwargs": { "line": 100, "dump": 1 }
+  },
+
+  {
+    "name": "Diff-dt-h",
+    "class": "renderers.Histogram1D",
+    "observe": [ "Diff-dt" ],
+    "kwargs": {
+      "title": "Time difference",
+      "xlabel": "dt [s]",
+      "ylabel": "entries/0.1s",
+      "filename": "output/gen-liq-{}-{}-{}.png"
+    }
+  },
+
+  {
+    "name": "pickle",
+    "class": "renderers.PicklePayload",
+    "observe": [ "Diff-dt" ],
+    "kwargs": {
+      "filename": "output/pickle-{}-{}-{}.pickle"
+    }
+  },
+
+
+]
+

--- a/snewpdag/plugins/PickleInput.py
+++ b/snewpdag/plugins/PickleInput.py
@@ -1,0 +1,26 @@
+"""
+PickleInput
+Configuration options:
+  filename:  input filename
+"""
+import logging
+import pickle
+
+from snewpdag.dag import Node
+
+class PickleInput(Node):
+  def __init__(self, filename, **kwargs):
+    self.filename = filename
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    """
+    load pickle, but keep the following payload fields:  action, name, history
+    """
+    with open(self.filename, 'rb') as f:
+      d = pickle.load(f)
+    for k, v in d.items():
+      if k not in ('action', 'name', 'history'):
+        data[k] = v # shallow copy, which should be fine here
+    return data
+

--- a/snewpdag/plugins/PickleInput.py
+++ b/snewpdag/plugins/PickleInput.py
@@ -1,6 +1,7 @@
 """
 PickleInput
 Configuration options:
+  on:  list of 'alert', 'report', 'revoke', 'reset' (default 'report')
   filename:  input filename
 """
 import logging
@@ -11,9 +12,10 @@ from snewpdag.dag import Node
 class PickleInput(Node):
   def __init__(self, filename, **kwargs):
     self.filename = filename
+    self.on = kwargs.pop('on', [ 'report' ])
     super().__init__(**kwargs)
 
-  def alert(self, data):
+  def ops(self, data):
     """
     load pickle, but keep the following payload fields:  action, name, history
     """
@@ -23,4 +25,16 @@ class PickleInput(Node):
       if k not in ('action', 'name', 'history'):
         data[k] = v # shallow copy, which should be fine here
     return data
+
+  def alert(self, data):
+    return self.ops(data) if 'alert' in self.on else False
+
+  def revoke(self, data):
+    return self.ops(data) if 'revoke' in self.on else True
+
+  def reset(self, data):
+    return self.ops(data) if 'reset' in self.on else True
+
+  def report(self, data):
+    return self.ops(data) if 'report' in self.on else False
 

--- a/snewpdag/plugins/__init__.py
+++ b/snewpdag/plugins/__init__.py
@@ -49,3 +49,5 @@ from .Chi2Prob import Chi2Prob
 from .DtsCalculator import DtsCalculator
 from .DiffPointing import DiffPointing
 
+from .PickleInput import PickleInput
+

--- a/snewpdag/plugins/renderers/PickleOutput.py
+++ b/snewpdag/plugins/renderers/PickleOutput.py
@@ -1,5 +1,5 @@
 """
-PicklePayload
+PickleOutput
 Configuration options:
   filename:  output filename, with fields
              {0} renderer name
@@ -11,7 +11,7 @@ import pickle
 
 from snewpdag.dag import Node
 
-class PicklePayload(Node):
+class PickleOutput(Node):
   def __init__(self, filename, **kwargs):
     self.filename = filename
     self.count = 0

--- a/snewpdag/plugins/renderers/PicklePayload.py
+++ b/snewpdag/plugins/renderers/PicklePayload.py
@@ -1,0 +1,32 @@
+"""
+PicklePayload
+Configuration options:
+  filename:  output filename, with fields
+             {0} renderer name
+             {1} count index, starting from 0
+             {2} burst_id from update data (default 0 if no such field)
+"""
+import logging
+import pickle
+
+from snewpdag.dag import Node
+
+class PicklePayload(Node):
+  def __init__(self, filename, **kwargs):
+    self.filename = filename
+    self.count = 0
+    super().__init__(**kwargs)
+
+  def write_pickle(self, data):
+    burst_id = data.get('burst_id', 0)
+    fname = self.filename.format(self.name, self.count, burst_id)
+    with open(fname, 'wb') as f:
+      pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
+    return True
+
+  def alert(self, data):
+    return self.write_pickle(data)
+
+  def report(self, data):
+    return self.write_pickle(data)
+

--- a/snewpdag/plugins/renderers/__init__.py
+++ b/snewpdag/plugins/renderers/__init__.py
@@ -8,3 +8,6 @@ from .Mollview import Mollview
 
 from .DistErrPlot import DistErrPlot
 from .ScatterPlot import ScatterPlot
+
+from .PicklePayload import PicklePayload
+

--- a/snewpdag/plugins/renderers/__init__.py
+++ b/snewpdag/plugins/renderers/__init__.py
@@ -9,5 +9,5 @@ from .Mollview import Mollview
 from .DistErrPlot import DistErrPlot
 from .ScatterPlot import ScatterPlot
 
-from .PicklePayload import PicklePayload
+from .PickleOutput import PickleOutput
 


### PR DESCRIPTION
Modules PickleInput and renderers.PicklePayload (maybe should change the name of the latter):  to pickle the payload and read it back in.  This should be useful for reproducing calculations.

Note "make pickle_input" doesn't quite work yet because renderers.Histogram1D responds to report rather than alert.  Something we should be able to adjust:  PicklePayload can create a pickle on alert or report, and ideally we restore the pickle with the same action.
