### PR TITLE
Option to get filename from payload

### DIFF
--- a/snewpdag/dag/lib.py
+++ b/snewpdag/dag/lib.py
@@ -4,7 +4,6 @@ DAG library routines
 import logging
 import numbers
 import numpy as np
-from astropy.time import Time
 
 # deprecated: ns_per_second
 # deprecated: time_tuple_from_float(x)
@@ -41,4 +40,23 @@ def fetch_field(data, fields):
       return data[fs], True
     else:
       return None, False
+
+def fill_filename(pattern, module_name, count, data):
+  """
+  Get filename, and fill out the details.
+  pattern = '[field specifier]' - fetch pattern from payload using fetch_field.
+    'filename' - use this literal string as the pattern.
+  The pattern is filled as follows:
+    {0} - module_name
+    {1} - count
+    {2} - data['burst_id']
+  """
+  ps = pattern.strip()
+  if ps[0] == '[' and ps[-1] == ']':
+    s, valid = fetch_field(data, ps[1:-1])
+    if not valid:
+      return None
+    ps = s.strip()
+  fn = ps.format(module_name, count, data.get('burst_id', 0))
+  return fn
 

--- a/snewpdag/plugins/JsonAlertInput.py
+++ b/snewpdag/plugins/JsonAlertInput.py
@@ -10,9 +10,9 @@ Note that the action field cannot be overwritten.
 import logging
 import json
 import sys
-import ast
 
 from snewpdag.dag import Node
+from snewpdag.dag.lib import fill_filename
 
 class JsonAlertInput(Node):
   def __init__(self, filename, **kwargs):
@@ -21,9 +21,14 @@ class JsonAlertInput(Node):
     super().__init__(**kwargs)
 
   def alert(self, data):
+    fname = fill_filename(self.filename, self.name, self.count, data)
+    if fname == None:
+      logging.error('{}: error interpreting {}', self.name, self.filename)
+      return False
     try:
-      with open(self.filename.format(self.count), 'r') as f:
-        d = ast.literal_eval(f.read())
+      with open(fname, 'r') as f:
+        #d = ast.literal_eval(f.read())
+        d = json.load(f)
     except:
       logging.error('{}: exception while reading file {}: {}'.format( \
           self.name, self.filename.format(self.count), sys.exc_info()))

--- a/snewpdag/plugins/PickleInput.py
+++ b/snewpdag/plugins/PickleInput.py
@@ -8,6 +8,7 @@ import logging
 import pickle
 
 from snewpdag.dag import Node
+from snewpdag.dag.lib import fill_filename
 
 class PickleInput(Node):
   def __init__(self, filename, **kwargs):
@@ -19,7 +20,11 @@ class PickleInput(Node):
     """
     load pickle, but keep the following payload fields:  action, name, history
     """
-    with open(self.filename, 'rb') as f:
+    fname = fill_filename(self.filename, self.name, 0, data)
+    if fname == None:
+      logging.error('{}: error interpreting {}', self.name, self.filename)
+      return False
+    with open(fname, 'rb') as f:
       d = pickle.load(f)
     for k, v in d.items():
       if k not in ('action', 'name', 'history'):

--- a/snewpdag/plugins/renderers/DistErrPlot.py
+++ b/snewpdag/plugins/renderers/DistErrPlot.py
@@ -24,6 +24,7 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 from snewpdag.dag import Node
+from snewpdag.dag.lib import fill_filename
 
 class DistErrPlot(Node):
     def __init__(self, title, xlabel, ylabel, filename, **kwargs):
@@ -37,7 +38,8 @@ class DistErrPlot(Node):
 #        self.true_dist = np.linspace(self.xlow, self.xhigh, self.xno, endpoint=True)
         super().__init__(**kwargs)
 
-    def render(self, true_dist, rel_err, exp_rel_dist1_stats, exp_rel_dist2_stats, exp_rel_mdist_stats):
+    def render(self, fname, true_dist, rel_err, exp_rel_dist1_stats, \
+               exp_rel_dist2_stats, exp_rel_mdist_stats):
         fig, ax = plt.subplots()
         ax.plot(true_dist, rel_err, label="Data")
         ax.plot(true_dist, exp_rel_dist1_stats, label="Expected (dist1)")
@@ -48,7 +50,7 @@ class DistErrPlot(Node):
         ax.set_title('{0}'.format(self.title))
         ax.legend()
         fig.tight_layout()
-        fname = self.filename.format(self.name, 0, 0)
+        #fname = self.filename.format(self.name, 0, 0)
         plt.savefig(fname)
 
     def report(self, data):
@@ -60,5 +62,11 @@ class DistErrPlot(Node):
         exp_rel_dist1_stats = data["exp_rel_dist1_stats"]
         exp_rel_dist2_stats = data["exp_rel_dist2_stats"]
         exp_rel_mdist_stats = data["exp_rel_mdist_stats"]
-        self.render(true_dist, rel_err, exp_rel_dist1_stats, exp_rel_dist2_stats, exp_rel_mdist_stats)
+        fname = fill_filename(self.filename, self.name, 0, data)
+        if fname == None:
+          logging.error('{}: error interpreting {}', self.name, self.filename)
+        else:
+          self.render(fname, true_dist, rel_err, exp_rel_dist1_stats, \
+                      exp_rel_dist2_stats, exp_rel_mdist_stats)
         return True
+

--- a/snewpdag/plugins/renderers/FitsSkymap.py
+++ b/snewpdag/plugins/renderers/FitsSkymap.py
@@ -106,6 +106,7 @@ from astropy.time import Time
 from astropy.table import Table
 
 from snewpdag.dag import Node
+from snewpdag.dag.lib import fill_filename
 
 class FitsSkymap(Node):
 
@@ -159,8 +160,12 @@ class FitsSkymap(Node):
     #                      #column_units='pix-1',
     #                      #extra_header=headers,
     #                      dtype=np.float32, overwrite=True)
-    fname = self.filename.format(self.name, self.count, burst_id)
-    self.write_file(m, burst_id, fname)
-    self.count += 1
+    #fname = self.filename.format(self.name, self.count, burst_id)
+    fname = fill_filename(self.filename, self.name, self.count, data)
+    if fname == None:
+      logging.error('{}: error interpreting {}', self.name, self.filename)
+    else:
+      self.write_file(m, burst_id, fname)
+      self.count += 1
     return True
 

--- a/snewpdag/plugins/renderers/Hist1D.py
+++ b/snewpdag/plugins/renderers/Hist1D.py
@@ -27,6 +27,7 @@ import numpy as np
 import matplotlib.mlab as mlab
 
 from snewpdag.dag import Node
+from snewpdag.dag.lib import fill_filename
 
 class Hist1D(Node):
   def __init__(self, in_field, title, xlabel, ylabel, filename, **kwargs):
@@ -39,7 +40,7 @@ class Hist1D(Node):
     self.count = 0 # number of histograms made
     super().__init__(**kwargs)
 
-  def plot(self, burst_id, hist):
+  def plot(self, fname, burst_id, hist):
     logging.debug('Hist1D.plot called')
     step = (hist.xhigh - hist.xlow) / hist.nbins
     x = np.arange(hist.xlow, hist.xhigh, step)
@@ -55,7 +56,6 @@ class Hist1D(Node):
                  self.title, burst_id, self.count))
     fig.tight_layout()
 
-    fname = self.filename.format(self.name, self.count, burst_id)
     plt.savefig(fname)
     logging.info('=====================')
     logging.info('H Filename:  {}'.format(fname))
@@ -75,7 +75,11 @@ class Hist1D(Node):
       # because I can't figure out how to use isinstance
       # for a class in a module (!)
       burst_id = data.get('burst_id', 0)
-      self.plot(burst_id, hist)
+      fname = fill_filename(self.filename, self.name, self.count, data)
+      if fname == None:
+        logging.error('{}: error interpreting {}', self.name, self.filename)
+        return False
+      self.plot(fname, burst_id, hist)
     return True # always return True
 
   def alert(self, data):

--- a/snewpdag/plugins/renderers/JsonOutput.py
+++ b/snewpdag/plugins/renderers/JsonOutput.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from snewpdag.dag import Node
 from snewpdag.values import TimeSeries
-from snewpdag.dag.lib import fetch_field
+from snewpdag.dag.lib import fetch_field, fill_filename
 
 def json_output_default(obj):
   if isinstance(obj, np.ndarray):
@@ -53,12 +53,14 @@ class JsonOutput(Node):
         d[f] = v
     #logging.info('{}: dict = {}'.format(self.name, d))
 
-    burst_id = data.get('burst_id', 0)
-    fname = self.filename.format(self.name, self.count, burst_id)
-    with open(fname, "w") as outfile:
-      json.dump(d, outfile, default=json_output_default)
+    fname = fill_filename(self.filename, self.name, self.count, data)
+    if fname == None:
+      logging.error('{}: error interpreting {}', self.name, self.filename)
+    else:
+      with open(fname, "w") as outfile:
+        json.dump(d, outfile, default=json_output_default)
 
-    self.count += 1
+      self.count += 1
     return True
 
   def alert(self, data):

--- a/snewpdag/plugins/renderers/Mollview.py
+++ b/snewpdag/plugins/renderers/Mollview.py
@@ -18,6 +18,7 @@ import numpy as np
 import healpy as hp
 
 from snewpdag.dag import Node
+from snewpdag.dag.lib import fill_filename
 from snewpdag.values import LMap
 
 class Mollview(Node):
@@ -35,7 +36,10 @@ class Mollview(Node):
     super().__init__(**kwargs)
 
   def plot(self, data):
-    burst_id = data.get('burst_id', 0)
+    fname = fill_filename(self.filename, self.name, self.count, data)
+    if fname == None:
+      logging.error('{}: error interpreting {}', self.name, self.filename)
+      return False
     if self.in_field in data:
       m = data[self.in_field]
       # replace a lot of these options later
@@ -55,7 +59,6 @@ class Mollview(Node):
                   **kwargs,
                  )
       hp.graticule()
-      fname = self.filename.format(self.name, self.count, burst_id)
       plt.savefig(fname)
       self.count += 1
     return True

--- a/snewpdag/plugins/renderers/PickleOutput.py
+++ b/snewpdag/plugins/renderers/PickleOutput.py
@@ -10,6 +10,7 @@ import logging
 import pickle
 
 from snewpdag.dag import Node
+from snewpdag.dag.lib import fill_filename
 
 class PickleOutput(Node):
   def __init__(self, filename, **kwargs):
@@ -18,8 +19,10 @@ class PickleOutput(Node):
     super().__init__(**kwargs)
 
   def write_pickle(self, data):
-    burst_id = data.get('burst_id', 0)
-    fname = self.filename.format(self.name, self.count, burst_id)
+    fname = fill_filename(self.filename, self.name, self.count, data)
+    if fname == None:
+      logging.error('{}: error interpreting {}', self.name, self.filename)
+      return False
     with open(fname, 'wb') as f:
       pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
     self.count += 1

--- a/snewpdag/plugins/renderers/ScatterPlot.py
+++ b/snewpdag/plugins/renderers/ScatterPlot.py
@@ -21,7 +21,9 @@ Constructor arguments:
 import logging
 import matplotlib.pyplot as plt
 import numpy as np
+
 from snewpdag.dag import Node
+from snewpdag.values import TimeSeries
 
 class ScatterPlot(Node):
     def __init__(self, title, xlabel, ylabel, filename, **kwargs):
@@ -39,7 +41,7 @@ class ScatterPlot(Node):
         self.logy = "logy" in f
         super().__init__(**kwargs)
 
-    def render(self, x, y):
+    def render(self, fname, x, y):
         fig, ax = plt.subplots()
         ax.plot(x, y, 'x')
         if self.line != None:
@@ -53,13 +55,17 @@ class ScatterPlot(Node):
         if self.logy: ax.set_yscale('log')
         if self.line != None: plt.legend()
         fig.tight_layout()
-        fname = self.filename.format(self.name)
         plt.savefig(fname)        
 
     def report(self, data):
         x = data[self.x_in_field][self.x_in_field2] if self.x_in_field2 != None else data[self.x_in_field]
         y = data[self.y_in_field][self.y_in_field2] if self.y_in_field2 != None else data[self.y_in_field]
-        self.render(x, y)
+        fname = fill_filename(self.filename, self.name, 0, data)
+        if fname == None:
+          logging.error('{}: error interpreting {}', self.name, self.filename)
+        else:
+          self.render(fname, x, y)
         #logging.info('{0}:{1}'.format(self.x_in_field, x))
         #logging.info('{0}:{1}'.format(self.y_in_field, np.around(y, decimals=2)))
         return True
+

--- a/snewpdag/tests/test_lib.py
+++ b/snewpdag/tests/test_lib.py
@@ -2,7 +2,7 @@
 Unit tests for dag library methods
 """
 import unittest
-from snewpdag.dag.lib import fetch_field
+from snewpdag.dag.lib import fetch_field, fill_filename
 
 class TestLib(unittest.TestCase):
 
@@ -51,4 +51,12 @@ class TestLib(unittest.TestCase):
     v, flag = fetch_field(data4, 'f41/f31/f20/f11')
     self.assertTrue(flag)
     self.assertEqual(v, 11)
+
+  def test_fill_filename(self):
+    dd = { 'f21': 'payload_{0}_{1}_{2}.png' }
+    data = { 'burst_id': 18, 'dd': dd }
+    s = fill_filename('test_{0}_{1}_{2}.png', 'mname', 23, data)
+    self.assertEqual(s, 'test_mname_23_18.png')
+    s = fill_filename(' [dd/f21]  ', 'dname', 24, data)
+    self.assertEqual(s, 'payload_dname_24_18.png')
 


### PR DESCRIPTION
Introduces a library function fill_filename, which can take a filename pattern literal as before (filled with {0} module name, {1} count, and {2} burst_id), or read the pattern from the payload.  To do the latter, specify the filename in the configuration file inside square brackets, e.g., '[field/subfield/subsubfield]'