### PR TITLE
top-down time series comparison

### DIFF
--- a/snewpdag/data/topdown-logl.csv
+++ b/snewpdag/data/topdown-logl.csv
@@ -24,10 +24,10 @@
 ,,,,,
 "Test","Pass","SNOP-data,SK-data,IC-data","'line':1, 'dump':1"
 ,,,,,
-"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
+"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'method':'poisson','in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
 "makemap-out","Pass","makemap","'line':1,'dump':1"
 ,,,,,
-"prob","LogLProb","makemap","'in_field':'map', 'out_field':'probmap'"
+"prob","LogLProb","makemap","'in_field':'chi2', 'out_field':'probmap'"
 "prob-out","Pass","prob","'line':1, 'dump':1"
 "probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Probability from LogL', 'units':'probability', 'coord':['C'], 'filename':'output/topdown-logl-{}-{}-{}.png'"
 "probfits","renderers.FitsSkymap","prob","'in_field':'probmap', 'filename':'output/topdown-logl-{}-{}-{}.fits'"

--- a/snewpdag/data/topdown-logl.csv
+++ b/snewpdag/data/topdown-logl.csv
@@ -24,7 +24,7 @@
 ,,,,,
 "Test","Pass","SNOP-data,SK-data,IC-data","'line':1, 'dump':1"
 ,,,,,
-"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':10,'twidth':1.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
+"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
 "makemap-out","Pass","makemap","'line':1,'dump':1"
 ,,,,,
 "prob","LogLProb","makemap","'in_field':'map', 'out_field':'probmap'"

--- a/snewpdag/data/topdown-logl.csv
+++ b/snewpdag/data/topdown-logl.csv
@@ -1,0 +1,39 @@
+"Control","Pass",,"'line': 100"
+,,,,,
+"SN-times","gen.TrueTimes","Control","'detector_location':'snewpdag/data/detector_location.csv', 'detectors': ['SNOP','SK','IC'], 'ra':-60.0, 'dec':-30.0, 'time':'2021-11-01 05:22:36.328'"
+"SN","Write","SN-times","'on':['alert'],'write':(('coincident_detectors',['SNOP','SK','IC']),)"
+"SN-out","Pass","SN","'line':1, 'dump':1"
+,,,,,
+"M27-SNOP-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-SNOP-signal","gen.GenTimeDist","M27-SNOP-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','SNOP','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+"M27-SNOP-hist","ops.TimeSeriesToHist1D","M27-SNOP-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+"M27-SNOP-render","renderers.Hist1D","M27-SNOP-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 SNO+','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/topdown-logl-{}-{}-{}.png'"
+"SNOP-data","Write","M27-SNOP-signal","'on':['alert'],'write':(('detector','SNOP'),)"
+,,,,,
+"M27-SK-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-SK-signal","gen.GenTimeDist","M27-SK-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','SK','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+"M27-SK-hist","ops.TimeSeriesToHist1D","M27-SK-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+"M27-SK-render","renderers.Hist1D","M27-SK-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 SK','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/topdown-logl-{}-{}-{}.png'"
+"SK-data","Write","M27-SK-signal","'on':['alert'],'write':(('detector','SK'),)"
+,,,,,
+"M27-IC-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-IC-signal","gen.GenTimeDist","M27-IC-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','IC','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+"M27-IC-hist","ops.TimeSeriesToHist1D","M27-IC-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+"M27-IC-render","renderers.Hist1D","M27-IC-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 IceCube','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/topdown-logl-{}-{}-{}.png'"
+"IC-data","Write","M27-IC-signal","'on':['alert'],'write':(('detector','IC'),)"
+,,,,,
+"Test","Pass","SNOP-data,SK-data,IC-data","'line':1, 'dump':1"
+,,,,,
+"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':10,'twidth':1.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
+"makemap-out","Pass","makemap","'line':1,'dump':1"
+,,,,,
+"prob","LogLProb","makemap","'in_field':'map', 'out_field':'probmap'"
+"prob-out","Pass","prob","'line':1, 'dump':1"
+"probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Probability from LogL', 'units':'probability', 'coord':['C'], 'filename':'output/topdown-logl-{}-{}-{}.png'"
+"probfits","renderers.FitsSkymap","prob","'in_field':'probmap', 'filename':'output/topdown-logl-{}-{}-{}.fits'"
+,,,,,
+"conf","ProbCL","prob","'in_field':'probmap', 'out_field':'clmap'"
+"conf-out","Pass","conf","'line':1, 'dump':1"
+"confmap","renderers.Mollview","conf","'in_field':'clmap', 'title':'CL from LogL', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/topdown-logl-{}-{}-{}.png'"
+"conffits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/topdown-logl-{}-{}-{}.fits'"
+,,,,,

--- a/snewpdag/data/topdown-trials.csv
+++ b/snewpdag/data/topdown-trials.csv
@@ -1,0 +1,46 @@
+"Control","Pass",,"'line': 100"
+,,,,,
+"SN-times","gen.TrueTimes","Control","'detector_location':'snewpdag/data/detector_location.csv', 'detectors': ['SNOP','SK','IC'], 'ra':-60.0, 'dec':-30.0, 'time':'2021-11-01 05:22:36.328'"
+"SN","Write","SN-times","'on':['alert'],'write':(('coincident_detectors',['SNOP','SK','IC']),)"
+"SN-out","Pass","SN","'line':1, 'dump':1"
+,,,,,
+"M27-SNOP-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-SNOP-signal","gen.GenTimeDist","M27-SNOP-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','SNOP','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+,,,,,"M27-SNOP-hist","ops.TimeSeriesToHist1D","M27-SNOP-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+,,,,,"M27-SNOP-render","renderers.Hist1D","M27-SNOP-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 SNO+','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/tt-{}-{}-{}.png'"
+"SNOP-data","Write","M27-SNOP-signal","'on':['alert'],'write':(('detector','SNOP'),)"
+,,,,,
+"M27-SK-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-SK-signal","gen.GenTimeDist","M27-SK-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','SK','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+,,,,,"M27-SK-hist","ops.TimeSeriesToHist1D","M27-SK-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+,,,,,"M27-SK-render","renderers.Hist1D","M27-SK-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 SK','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/tt-{}-{}-{}.png'"
+"SK-data","Write","M27-SK-signal","'on':['alert'],'write':(('detector','SK'),)"
+,,,,,
+"M27-IC-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-IC-signal","gen.GenTimeDist","M27-IC-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','IC','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+,,,,,"M27-IC-hist","ops.TimeSeriesToHist1D","M27-IC-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+,,,,,"M27-IC-render","renderers.Hist1D","M27-IC-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 IceCube','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/tt-{}-{}-{}.png'"
+"IC-data","Write","M27-IC-signal","'on':['alert'],'write':(('detector','IC'),)"
+,,,,,
+"Test","Pass","SNOP-data,SK-data,IC-data","'line':1, 'dump':1"
+,,,,,
+"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
+"makemap-out","Pass","makemap","'line':1,'dump':1"
+,,,,,
+,,,,,"prob","Chi2Prob","makemap","'in_field':'map', 'out_field':'probmap'"
+,,,,,"prob-out","Pass","prob","'line':1, 'dump':1"
+,,,,,"probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Map evaluation', 'units':'probability', 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
+,,,,,"probfits","renderers.FitsSkymap","prob","'in_field':'probmap', 'filename':'output/tt-{}-{}-{}.fits'"
+,,,,,
+"Conf","Chi2CL","makemap","'in_field':'map', 'out_field':'clmap'"
+,,,,,"conf-out","Pass","conf","'line':1, 'dump':1"
+,,,,,"confmap","renderers.Mollview","conf","'in_field':'clmap', 'title':'Map evaluation', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
+,,,,,"conffits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/tt-{}-{}-{}.fits'"
+,,,,,
+"Count","HistogramSkymap","makemap","'nside':8, 'in_field':'map_zeroes', 'out_field':'hist', 'out_err_field':'histerr'"
+"Count-out","Pass","Count","'line':1, 'dump':1"
+"Count-skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'MC trials', 'units':'Counts', 'range':(0,), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
+,,,,,
+"Norm","NormHistogram","Conf","'in_field':'clmap', 'out_field':'weights'"
+"Accumulate","AccHistogram","Norm","'in_field':'weights', 'out_field':'hist'"
+"Weight-skymap","renderers.Mollview","Accumulate","'on':['report'], 'in_field':'hist', 'title':'Weighted MC trials', 'units':'Weights', 'range':(0,), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"

--- a/snewpdag/data/topdown-trials.csv
+++ b/snewpdag/data/topdown-trials.csv
@@ -40,6 +40,8 @@
 "Count","HistogramSkymap","makemap","'nside':8, 'in_field':'map_zeroes', 'out_field':'hist', 'out_err_field':'histerr'"
 "Count-out","Pass","Count","'line':1, 'dump':1"
 "Count-skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'MC trials', 'units':'Counts', 'range':(0,), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
+"confCount","ProbCL","Count","'on':['report'],'in_field':'hist','out_field':'cclmap'"
+"confCountMap","renderers.Mollview","confCount","'on':['report'],'in_field':'cclmap', 'title':'CL from counts', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,
 "Norm","NormHistogram","conf","'in_field':'clmap', 'out_field':'weights'"
 "Accumulate","AccHistogram","Norm","'in_field':'weights', 'out_field':'hist'"

--- a/snewpdag/data/topdown-trials.csv
+++ b/snewpdag/data/topdown-trials.csv
@@ -27,12 +27,12 @@
 "makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
 "makemap-out","Pass","makemap","'line':1,'dump':1"
 ,,,,,
-,,,,,"prob","Chi2Prob","makemap","'in_field':'map', 'out_field':'probmap'"
+"prob","LogLProb","makemap","'in_field':'map', 'out_field':'probmap'"
 ,,,,,"prob-out","Pass","prob","'line':1, 'dump':1"
 ,,,,,"probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Map evaluation', 'units':'probability', 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,"probfits","renderers.FitsSkymap","prob","'in_field':'probmap', 'filename':'output/tt-{}-{}-{}.fits'"
 ,,,,,
-"Conf","Chi2CL","makemap","'in_field':'map', 'out_field':'clmap'"
+"conf","ProbCL","prob","'in_field':'probmap', 'out_field':'clmap'"
 ,,,,,"conf-out","Pass","conf","'line':1, 'dump':1"
 ,,,,,"confmap","renderers.Mollview","conf","'in_field':'clmap', 'title':'Map evaluation', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,"conffits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/tt-{}-{}-{}.fits'"
@@ -41,11 +41,11 @@
 "Count-out","Pass","Count","'line':1, 'dump':1"
 "Count-skymap","renderers.Mollview","Count","'on':['report'], 'in_field':'hist', 'title':'MC trials', 'units':'Counts', 'range':(0,), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,
-"Norm","NormHistogram","Conf","'in_field':'clmap', 'out_field':'weights'"
+"Norm","NormHistogram","conf","'in_field':'clmap', 'out_field':'weights'"
 "Accumulate","AccHistogram","Norm","'in_field':'weights', 'out_field':'hist'"
 "Weight-skymap","renderers.Mollview","Accumulate","'on':['report'], 'in_field':'hist', 'title':'Weighted MC trials', 'units':'Weights', 'range':(0,), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,
-"targetChi2","ops.FillHist1D","makemap","'in_field':('chi2',749),'out_field':'histchi2','nbins':100,'xlow':1800.0,'xhigh':2300.0"
+"targetChi2","ops.FillHist1D","makemap","'in_field':('chi2',749),'out_field':'histchi2','nbins':100,'xlow':0.0,'xhigh':500.0"
 "targetChi2-render","renderers.Hist1D","targetChi2","'on':['report'],'in_field':'histchi2','title':'Pixel 749 raw chi2','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
 "targetChi2Sub","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub','nbins':100,'xlow':0.0,'xhigh':10000.0"
 "targetChi2Sub-render","renderers.Hist1D","targetChi2Sub","'on':['report'],'in_field':'histsub','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"

--- a/snewpdag/data/topdown-trials.csv
+++ b/snewpdag/data/topdown-trials.csv
@@ -24,10 +24,10 @@
 ,,,,,
 "Test","Pass","SNOP-data,SK-data,IC-data","'line':1, 'dump':1"
 ,,,,,
-"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
+"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'method':'poisson','in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
 "makemap-out","Pass","makemap","'line':1,'dump':1"
 ,,,,,
-"prob","LogLProb","makemap","'in_field':'map', 'out_field':'probmap'"
+"prob","LogLProb","makemap","'in_field':'chi2', 'out_field':'probmap'"
 ,,,,,"prob-out","Pass","prob","'line':1, 'dump':1"
 ,,,,,"probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Map evaluation', 'units':'probability', 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,"probfits","renderers.FitsSkymap","prob","'in_field':'probmap', 'filename':'output/tt-{}-{}-{}.fits'"
@@ -43,16 +43,19 @@
 "confCount","ProbCL","Count","'on':['report'],'in_field':'hist','out_field':'cclmap'"
 "confCountMap","renderers.Mollview","confCount","'on':['report'],'in_field':'cclmap', 'title':'CL from counts', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,
+"targetCL","ops.FillHist1D","conf","'in_field':('clmap',749), 'out_field':'histcl','nbins':100,'xlow':0.0,'xhigh':1.0"
+"targetCL-render","renderers.Hist1D","targetCL","'on':['report'],'in_field':'histcl','title':'Pixel 749 CL','xlabel':'CL','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+,,,,,
 "Norm","NormHistogram","conf","'in_field':'clmap', 'out_field':'weights'"
 "Accumulate","AccHistogram","Norm","'in_field':'weights', 'out_field':'hist'"
 "Weight-skymap","renderers.Mollview","Accumulate","'on':['report'], 'in_field':'hist', 'title':'Weighted MC trials', 'units':'Weights', 'range':(0,), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
 ,,,,,
-"targetChi2","ops.FillHist1D","makemap","'in_field':('chi2',749),'out_field':'histchi2','nbins':100,'xlow':0.0,'xhigh':500.0"
-"targetChi2-render","renderers.Hist1D","targetChi2","'on':['report'],'in_field':'histchi2','title':'Pixel 749 raw chi2','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
-"targetChi2Sub","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub','nbins':100,'xlow':0.0,'xhigh':10000.0"
-"targetChi2Sub-render","renderers.Hist1D","targetChi2Sub","'on':['report'],'in_field':'histsub','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
-"targetChi2SubZoom1","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub1','nbins':100,'xlow':0.0,'xhigh':1000.0"
-"targetChi2SubZoom1-render","renderers.Hist1D","targetChi2SubZoom1","'on':['report'],'in_field':'histsub1','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+,,,,,"targetChi2","ops.FillHist1D","makemap","'in_field':('chi2',749),'out_field':'histchi2','nbins':100,'xlow':0.0,'xhigh':500.0"
+,,,,,"targetChi2-render","renderers.Hist1D","targetChi2","'on':['report'],'in_field':'histchi2','title':'Pixel 749 raw chi2','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+,,,,,"targetChi2Sub","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub','nbins':100,'xlow':0.0,'xhigh':10000.0"
+,,,,,"targetChi2Sub-render","renderers.Hist1D","targetChi2Sub","'on':['report'],'in_field':'histsub','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+,,,,,"targetChi2SubZoom1","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub1','nbins':100,'xlow':0.0,'xhigh':1000.0"
+,,,,,"targetChi2SubZoom1-render","renderers.Hist1D","targetChi2SubZoom1","'on':['report'],'in_field':'histsub1','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
 "targetChi2SubZoom2","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub2','nbins':100,'xlow':0.0,'xhigh':100.0"
 "targetChi2SubZoom2-render","renderers.Hist1D","targetChi2SubZoom2","'on':['report'],'in_field':'histsub2','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
 ,,,,,

--- a/snewpdag/data/topdown-trials.csv
+++ b/snewpdag/data/topdown-trials.csv
@@ -44,3 +44,13 @@
 "Norm","NormHistogram","Conf","'in_field':'clmap', 'out_field':'weights'"
 "Accumulate","AccHistogram","Norm","'in_field':'weights', 'out_field':'hist'"
 "Weight-skymap","renderers.Mollview","Accumulate","'on':['report'], 'in_field':'hist', 'title':'Weighted MC trials', 'units':'Weights', 'range':(0,), 'coord':['C'], 'filename':'output/tt-{}-{}-{}.png'"
+,,,,,
+"targetChi2","ops.FillHist1D","makemap","'in_field':('chi2',749),'out_field':'histchi2','nbins':100,'xlow':1800.0,'xhigh':2300.0"
+"targetChi2-render","renderers.Hist1D","targetChi2","'on':['report'],'in_field':'histchi2','title':'Pixel 749 raw chi2','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+"targetChi2Sub","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub','nbins':100,'xlow':0.0,'xhigh':10000.0"
+"targetChi2Sub-render","renderers.Hist1D","targetChi2Sub","'on':['report'],'in_field':'histsub','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+"targetChi2SubZoom1","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub1','nbins':100,'xlow':0.0,'xhigh':1000.0"
+"targetChi2SubZoom1-render","renderers.Hist1D","targetChi2SubZoom1","'on':['report'],'in_field':'histsub1','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+"targetChi2SubZoom2","ops.FillHist1D","makemap","'in_field':('map',749),'out_field':'histsub2','nbins':100,'xlow':0.0,'xhigh':100.0"
+"targetChi2SubZoom2-render","renderers.Hist1D","targetChi2SubZoom2","'on':['report'],'in_field':'histsub2','title':'Pixel 749 chi2 - chi2min','xlabel':'chi2','ylabel':'entries','filename':'output/tt-{}-{}-{}.png'"
+,,,,,

--- a/snewpdag/data/topdown.csv
+++ b/snewpdag/data/topdown.csv
@@ -27,13 +27,13 @@
 "makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
 "makemap-out","Pass","makemap","'line':1,'dump':1"
 ,,,,,
-"prob","Chi2Prob","makemap","'in_field':'map', 'out_field':'probmap'"
+"prob","LogLProb","makemap","'in_field':'map', 'out_field':'probmap'"
 "prob-out","Pass","prob","'line':1, 'dump':1"
-"probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Map evaluation', 'units':'probability', 'coord':['C'], 'filename':'output/topdown-{}-{}-{}.png'"
+"probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Probability from LogL', 'units':'probability', 'coord':['C'], 'filename':'output/topdown-{}-{}-{}.png'"
 "probfits","renderers.FitsSkymap","prob","'in_field':'probmap', 'filename':'output/topdown-{}-{}-{}.fits'"
 ,,,,,
-"conf","Chi2CL","makemap","'in_field':'map', 'out_field':'clmap'"
+"conf","ProbCL","prob","'in_field':'probmap', 'out_field':'clmap'"
 "conf-out","Pass","conf","'line':1, 'dump':1"
-"confmap","renderers.Mollview","conf","'in_field':'clmap', 'title':'Map evaluation', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/topdown-{}-{}-{}.png'"
+"confmap","renderers.Mollview","conf","'in_field':'clmap', 'title':'CL from LogL', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/topdown-{}-{}-{}.png'"
 "conffits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/topdown-{}-{}-{}.fits'"
 ,,,,,

--- a/snewpdag/data/topdown.csv
+++ b/snewpdag/data/topdown.csv
@@ -1,0 +1,39 @@
+"Control","Pass",,"'line': 100"
+,,,,,
+"SN-times","gen.TrueTimes","Control","'detector_location':'snewpdag/data/detector_location.csv', 'detectors': ['SNOP','SK','IC'], 'ra':-60.0, 'dec':-30.0, 'time':'2021-11-01 05:22:36.328'"
+"SN","Write","SN-times","'on':['alert'],'write':(('coincident_detectors',['SNOP','SK','IC']),)"
+"SN-out","Pass","SN","'line':1, 'dump':1"
+,,,,,
+"M27-SNOP-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-SNOP-signal","gen.GenTimeDist","M27-SNOP-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','SNOP','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+"M27-SNOP-hist","ops.TimeSeriesToHist1D","M27-SNOP-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+"M27-SNOP-render","renderers.Hist1D","M27-SNOP-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 SNO+','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/topdown-{}-{}-{}.png'"
+"SNOP-data","Write","M27-SNOP-signal","'on':['alert'],'write':(('detector','SNOP'),)"
+,,,,,
+"M27-SK-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-SK-signal","gen.GenTimeDist","M27-SK-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','SK','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+"M27-SK-hist","ops.TimeSeriesToHist1D","M27-SK-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+"M27-SK-render","renderers.Hist1D","M27-SK-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 SK','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/topdown-{}-{}-{}.png'"
+"SK-data","Write","M27-SK-signal","'on':['alert'],'write':(('detector','SK'),)"
+,,,,,
+"M27-IC-new","ops.NewTimeSeries","SN","'out_field':'timeseries','start':'2021-11-01 05:22:34'"
+"M27-IC-signal","gen.GenTimeDist","M27-IC-new","'field':'timeseries','sig_mean':10000,'sig_t0':('truth','dets','IC','true_t'),'sig_filetype':'tng','sig_filename':'/home/tseng/dev/snews/numodels/ls220-s27.0co/neutrino_signal_nubar_e-LS220-s27.0co.data'"
+"M27-IC-hist","ops.TimeSeriesToHist1D","M27-IC-signal","'in_field':'timeseries','out_field':'timeserieshist','start':'2021-11-01 05:22:34','stop':'2021-11-01 05:22:44','nbins':100"
+"M27-IC-render","renderers.Hist1D","M27-IC-hist","'on':['alert'],'in_field':'timeserieshist','title':'M27 IceCube','xlabel':'t [s]','ylabel':'entries/10ms','filename':'output/topdown-{}-{}-{}.png'"
+"IC-data","Write","M27-IC-signal","'on':['alert'],'write':(('detector','IC'),)"
+,,,,,
+"Test","Pass","SNOP-data,SK-data,IC-data","'line':1, 'dump':1"
+,,,,,
+"makemap","TopDownSeries","SNOP-data,SK-data,IC-data","'detector_location':'snewpdag/data/detector_location.csv','nside':8,'tnbins':100,'twidth':10.0,'in_field':'timeseries','in_det_field':'detector','in_det_list_field':'coincident_detectors'"
+"makemap-out","Pass","makemap","'line':1,'dump':1"
+,,,,,
+"prob","Chi2Prob","makemap","'in_field':'map', 'out_field':'probmap'"
+"prob-out","Pass","prob","'line':1, 'dump':1"
+"probmap","renderers.Mollview","prob","'in_field':'probmap', 'title':'Map evaluation', 'units':'probability', 'coord':['C'], 'filename':'output/topdown-{}-{}-{}.png'"
+"probfits","renderers.FitsSkymap","prob","'in_field':'probmap', 'filename':'output/topdown-{}-{}-{}.fits'"
+,,,,,
+"conf","Chi2CL","makemap","'in_field':'map', 'out_field':'clmap'"
+"conf-out","Pass","conf","'line':1, 'dump':1"
+"confmap","renderers.Mollview","conf","'in_field':'clmap', 'title':'Map evaluation', 'units':'CL', 'range':(0,1), 'coord':['C'], 'filename':'output/topdown-{}-{}-{}.png'"
+"conffits","renderers.FitsSkymap","conf","'in_field':'clmap', 'filename':'output/topdown-{}-{}-{}.fits'"
+,,,,,

--- a/snewpdag/plugins/LogLProb.py
+++ b/snewpdag/plugins/LogLProb.py
@@ -1,0 +1,32 @@
+"""
+LogLProb - take a log-likelihood map and turn it into probability map
+
+arguments:
+  prefactor: multiple by this before take exp, def -0.5 (for chi2-like input)
+  in_field: field name of log-likelihood values
+  out_field: field name of probability values
+"""
+import logging
+import numpy as np
+
+from snewpdag.dag import Node
+
+class LogLProb(Node):
+  def __init__(self, in_field, out_field, prefactor=-0.5, **kwargs):
+    self.in_field = in_field
+    self.out_field = out_field
+    self.prefactor = prefactor
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    if self.in_field in data:
+      m = np.array(data[self.in_field])
+      base = np.min(m)
+      v = np.exp((m - base) * self.prefactor)
+      sv = np.sum(v)
+      logging.info('Sum of probability map is {}'.format(sv))
+      data[self.out_field] = v / sv
+      return data
+    else:
+      return False
+

--- a/snewpdag/plugins/LogLProb.py
+++ b/snewpdag/plugins/LogLProb.py
@@ -21,8 +21,9 @@ class LogLProb(Node):
   def alert(self, data):
     if self.in_field in data:
       m = np.array(data[self.in_field])
-      base = np.min(m)
-      v = np.exp((m - base) * self.prefactor)
+      #base = np.min(m)
+      #v = np.exp((m - base) * self.prefactor)
+      v = np.exp(m * self.prefactor)
       sv = np.sum(v)
       logging.info('Sum of probability map is {}'.format(sv))
       data[self.out_field] = v / sv

--- a/snewpdag/plugins/ProbCL.py
+++ b/snewpdag/plugins/ProbCL.py
@@ -1,0 +1,33 @@
+"""
+ProbCL - turn a probability map into a CL map, using LIGO recipe.
+
+Arguments:
+  in_field: field name of probability values
+  out_field: field name of CL values
+
+CL values will have values from 0 (least probable) to 1 (most probable).
+The 90% confidence interval will include pixels with CL > 0.9.
+"""
+import logging
+import numpy as np
+
+from snewpdag.dag import Node
+
+class ProbCL(Node):
+  def __init__(self, in_field, out_field, **kwargs):
+    self.in_field = in_field
+    self.out_field = out_field
+    super().__init__(**kwargs)
+
+  def alert(self, data):
+    if self.in_field in data:
+      m = data[self.in_field]
+      i = np.flipud(np.argsort(m))
+      sorted_credible_levels = np.cumsum(m[i])
+      credible_levels = np.empty_like(sorted_credible_levels)
+      credible_levels[i] = sorted_credible_levels
+      data[self.out_field] = 1.0 - credible_levels
+      return data
+    else:
+      return False
+

--- a/snewpdag/plugins/ProbCL.py
+++ b/snewpdag/plugins/ProbCL.py
@@ -4,6 +4,10 @@ ProbCL - turn a probability map into a CL map, using LIGO recipe.
 Arguments:
   in_field: field name of probability values
   out_field: field name of CL values
+  on (optional): list of 'alert', 'reset', 'revoke', 'report'
+    (default ['alert'])
+
+The probability values in the array will be normalized to sum to 1.
 
 CL values will have values from 0 (least probable) to 1 (most probable).
 The 90% confidence interval will include pixels with CL > 0.9.
@@ -17,11 +21,13 @@ class ProbCL(Node):
   def __init__(self, in_field, out_field, **kwargs):
     self.in_field = in_field
     self.out_field = out_field
+    self.on = kwargs.pop('on', ['alert'])
     super().__init__(**kwargs)
 
-  def alert(self, data):
+  def process(self, data):
     if self.in_field in data:
-      m = data[self.in_field]
+      h = data[self.in_field]
+      m = h / np.sum(h)
       i = np.flipud(np.argsort(m))
       sorted_credible_levels = np.cumsum(m[i])
       credible_levels = np.empty_like(sorted_credible_levels)
@@ -30,4 +36,16 @@ class ProbCL(Node):
       return data
     else:
       return False
+
+  def alert(self, data):
+    return self.process(data) if 'alert' in self.on else True
+
+  def revoke(self, data):
+    return self.process(data) if 'revoke' in self.on else True
+
+  def reset(self, data):
+    return self.process(data) if 'reset' in self.on else True
+
+  def report(self, data):
+    return self.process(data) if 'report' in self.on else True
 

--- a/snewpdag/plugins/TopDownSeries.py
+++ b/snewpdag/plugins/TopDownSeries.py
@@ -73,8 +73,11 @@ class TopDownSeries(Node):
       for j in range(len(ref)): # loop over time bins
         if aa[i] > 0:
           pp = aa[i]*ref[j] # predicted area
+          ppi = np.floor(pp)
           if pp > 0:
-            x = nn[i,j] * np.log(pp) - pp - sc.gammaln(nn[i,j] + 1)
+            #x = nn[i,j] * np.log(pp) - pp - sc.gammaln(nn[i,j] + 1)
+            x = (nn[i,j] - ppi) * np.log(pp) + \
+                sc.gammaln(ppi + 1) - sc.gammaln(nn[i,j] + 1)
             chi2 += x
     chi2 *= -2.0
     return chi2

--- a/snewpdag/plugins/TopDownSeries.py
+++ b/snewpdag/plugins/TopDownSeries.py
@@ -109,10 +109,11 @@ class TopDownSeries(Node):
     #logging.debug('m = {}'.format(m))
     chi2_min = m.min()
     logging.debug('min = {}, max = {}'.format(chi2_min, m.max()))
-    m -= chi2_min
-    data['map'] = m
+    data['chi2'] = m
+    mm = m - chi2_min
+    data['map'] = mm
     data['ndof'] = 2 # need to confirm this
-    data['map_zeroes'] = np.flatnonzero(m == 0.0)
+    data['map_zeroes'] = np.flatnonzero(mm == 0.0)
     return data
 
   def alert(self, data):

--- a/snewpdag/plugins/TopDownSeries.py
+++ b/snewpdag/plugins/TopDownSeries.py
@@ -1,0 +1,147 @@
+"""
+TopDownSeries - top-down time series comparison, no background
+"""
+import logging
+import numpy as np
+import healpy as hp
+import scipy.special as sc
+from astropy.time import Time
+from astropy import units as u
+from astropy import constants as const
+
+from snewpdag.dag import Node, CelestialPixels
+from snewpdag.dag import DetectorDB
+from snewpdag.values import Hist1D, TimeSeries
+
+class TopDownSeries(Node):
+  def __init__(self, detector_location, nside, tnbins, twidth,
+               in_field, in_det_field, in_det_list_field,
+               **kwargs):
+    self.db = DetectorDB(detector_location)
+    self.nside = nside
+    self.npix = hp.nside2npix(nside)
+    self.tnbins = tnbins # nbins for time histogram
+    self.twidth = twidth # time span (s) for histogram
+    self.in_field = in_field
+    self.in_det_field = in_det_field
+    self.in_det_list_field = in_det_list_field
+    self.cache = {} # { <det> : <TimeSeries> }
+    super().__init__(**kwargs)
+
+  def reference_time(self):
+    tm = [ np.min(self.cache[k].times) for k in self.cache.keys() ]
+    return np.min(tm)
+
+  def compare(self, keys, tdelays):
+    """
+    Compare timing profiles for one sky position (set of time offsets)
+    keys = list of detectors
+    tdelays = time offsets in s, shape (nkeys,)
+    Return chi2-like measure.
+    """
+    # find earliest time
+    tstart = self.reference_time()
+    # bin the time series
+    hs = []
+    areas = []
+    for i in range(len(keys)):
+      k = keys[i]
+      # tdelays should be in s, but may be wrapped in a dimensionless Quantity
+      dt = tdelays[i].value if hasattr(tdelays[i], 'unit') else tdelays[i]
+      v = self.cache[k]
+      #logging.debug('times = {}'.format(v.times))
+      #logging.debug('  hasattr unit tnbins = {}, tstart = {}, dt = {}, twidth = {}'.format(hasattr(self.tnbins, 'unit'), hasattr(tstart, 'unit'), hasattr(dt, 'unit'), hasattr(self.twidth, 'unit')))
+      h, edges = v.histogram(self.tnbins,
+                             start=tstart - dt,
+                             stop=tstart + self.twidth - dt)
+      #logging.debug(f'h[{i}] = {h}')
+      hs.append(h) # total counts, shape (nkeys, nbins)
+      a = np.sum(h)
+      areas.append(a)
+    nn = np.array(hs)
+    aa = np.array(areas)
+
+    # reference profile
+    sigsum = np.sum(nn, 0) # sum within each time bin
+    ref = sigsum / np.sum(sigsum) # normalized reference profile
+
+    logging.debug('nn = {}'.format(nn))
+
+    # compare
+    chi2 = 0.0
+    for i in range(len(aa)): # loop over detectors
+      for j in range(len(ref)): # loop over time bins
+        if aa[i] > 0:
+          pp = aa[i]*ref[j] # predicted area
+          if pp > 0:
+            x = nn[i,j] * np.log(pp) - pp - sc.gammaln(nn[i,j] + 1)
+            chi2 += x
+    chi2 *= -2.0
+    return chi2
+
+  def reevaluate(self, data):
+    """
+    Call compare() for each skymap pixel
+    """
+    # get directions for each pixel
+    t0 = self.reference_time()
+    t0a = Time(t0, format='unix')
+    cp = CelestialPixels()
+    rs = cp.get_map(self.nside, t0) # shape (3,npix)
+
+    # get nominal time shifts for each detector for each pixel
+    keys = list(self.cache.keys())
+    nkeys = len(keys)
+    pd = np.zeros([nkeys, 3])
+    i = 0
+    for k in keys:
+      det = self.db.get(k) # Detector object
+      pd[i] = det.get_xyz(t0a) # GCRS coordinates at time [m]
+      i += 1
+    tdet = pd @ rs / 3.0e8 # time offsets in s, rel to Earth center
+    # shape of tdet should be (nkeys,npix)
+
+    # get reference signal profile for each pixel's hypothetical direction
+    m = np.zeros(self.npix)
+    for i in range(self.npix):
+      m[i] = self.compare(keys, tdet[...,i])
+
+    #logging.debug('m = {}'.format(m))
+    chi2_min = m.min()
+    logging.debug('min = {}, max = {}'.format(chi2_min, m.max()))
+    m -= chi2_min
+    data['map'] = m
+    data['ndof'] = 2 # need to confirm this
+    data['map_zeroes'] = np.flatnonzero(m == 0.0)
+    return data
+
+  def alert(self, data):
+    logging.debug('{}: alert'.format(self.name))
+    logging.debug('{}: pre cached {}'.format(self.name, self.cache.keys()))
+    if self.in_field in data and self.in_det_field in data:
+      self.cache[data[self.in_det_field]] = data[self.in_field]
+      logging.debug('{}: post cached {}'.format(self.name, self.cache.keys()))
+      if self.in_det_list_field in data:
+        logging.debug('{}: in_det_list_field -> {}'.format(self.name, data[self.in_det_list_field]))
+        if set(self.cache.keys()) == set(data[self.in_det_list_field]):
+          # evaluate skymap if all the detectors in cache
+          return self.reevaluate(data)
+    return False
+
+  def revoke(self, data):
+    logging.debug('{}: revoke'.format(self.name))
+    if self.in_det_field in data:
+      k = data[self.in_det_field]
+      if k in self.cache:
+        del self.cache[k]
+        return True # force reevaluations downstream since there's a change
+    return False
+
+  def reset(self, data):
+    logging.debug('{}: reset'.format(self.name))
+    if len(self.cache) > 0:
+      self.cache = {}
+      return True
+    else:
+      return False
+

--- a/snewpdag/plugins/__init__.py
+++ b/snewpdag/plugins/__init__.py
@@ -49,7 +49,8 @@ from .Chi2Prob import Chi2Prob
 #from .DtsCalculator import DtsCalculator # needs to be updated
 from .DiffTimes import DiffTimes
 from .DiffPointing import DiffPointing
-from .EvalMap import EvalMap
+#from .EvalMap import EvalMap
+from .TopDownSeries import TopDownSeries
 
 from .PickleInput import PickleInput
 from .JsonAlertInput import JsonAlertInput

--- a/snewpdag/plugins/__init__.py
+++ b/snewpdag/plugins/__init__.py
@@ -45,6 +45,8 @@ from .TrueVsFit import TrueVsFit
 from .Chi2Calculator import Chi2Calculator
 from .Chi2CL import Chi2CL
 from .Chi2Prob import Chi2Prob
+from .LogLProb import LogLProb
+from .ProbCL import ProbCL
 
 #from .DtsCalculator import DtsCalculator # needs to be updated
 from .DiffTimes import DiffTimes

--- a/snewpdag/plugins/gen/GenTimeDist.py
+++ b/snewpdag/plugins/gen/GenTimeDist.py
@@ -72,7 +72,7 @@ class GenTimeDist(TimeDistSource):
       GenTimeDist.one_mean = self.sig_mean
 
   def alert(self, data):
-    v, flag = fetch_field(self.field)
+    v, flag = fetch_field(data, self.field)
     if flag:
 
       # epoch base

--- a/snewpdag/plugins/ops/NewHist1D.py
+++ b/snewpdag/plugins/ops/NewHist1D.py
@@ -9,7 +9,7 @@ Arguments:
 """
 import logging
 import numpy as np
-
+from astropy.time import Time
 from snewpdag.dag import Node
 from snewpdag.values import Hist1D
 
@@ -18,7 +18,11 @@ class NewHist1D(Node):
     self.out_field = out_field
     self.nbins = nbins
     self.start = start
+    if isinstance(self.start, str):
+      self.start = Time(self.start).to_value('unix', 'long')
     self.stop = stop
+    if isinstance(self.stop, str):
+      self.stop = Time(self.stop).to_value('unix', 'long')
     super().__init__(**kwargs)
 
   def alert(self, data):

--- a/snewpdag/plugins/ops/NewTimeSeries.py
+++ b/snewpdag/plugins/ops/NewTimeSeries.py
@@ -9,7 +9,7 @@ Arguments:
 import logging
 import numpy as np
 import numbers
-
+from astropy.time import Time
 from snewpdag.dag import Node
 from snewpdag.values import TimeSeries
 
@@ -17,7 +17,11 @@ class NewTimeSeries(Node):
   def __init__(self, out_field, **kwargs):
     self.out_field = out_field
     self.start = kwargs.pop('start', None)
+    if isinstance(self.start, str):
+      self.start = Time(self.start).to_value('unix', 'long')
     self.stop = kwargs.pop('stop', None)
+    if isinstance(self.stop, str):
+      self.stop = Time(self.stop).to_value('unix', 'long')
     super().__init__(**kwargs)
 
   def alert(self, data):

--- a/snewpdag/plugins/ops/TimeSeriesToHist1D.py
+++ b/snewpdag/plugins/ops/TimeSeriesToHist1D.py
@@ -10,7 +10,7 @@ Arguments:
 """
 import logging
 import numpy as np
-
+from astropy.time import Time
 from snewpdag.dag import Node
 from snewpdag.values import Hist1D, TimeSeries
 
@@ -20,7 +20,11 @@ class TimeSeriesToHist1D(Node):
     self.out_field = out_field
     self.nbins = nbins
     self.start = start
+    if isinstance(self.start, str):
+      self.start = Time(self.start).to_value('unix', 'long')
     self.stop = stop
+    if isinstance(self.stop, str):
+      self.stop = Time(self.stop).to_value('unix', 'long')
     super().__init__(**kwargs)
 
   def alert(self, data):

--- a/snewpdag/values/Hist1D.py
+++ b/snewpdag/values/Hist1D.py
@@ -20,6 +20,16 @@ class Hist1D:
     self.sum2 = 0.0
     self.count = 0
 
+  def copy(self):
+    h = Hist1D(self.nbins, self.xlow, self.xhigh)
+    h.bins = self.bins.copy()
+    h.overflow = self.overflow
+    h.underflow = self.underflow
+    h.sum = self.sum
+    h.sum2 = self.sum2
+    h.count = self.count
+    return h
+
   def is_compatible(self, other):
     if isinstance(other, Hist1D):
       return self.nbins == other.nbins and \

--- a/snewpdag/values/TimeSeries.py
+++ b/snewpdag/values/TimeSeries.py
@@ -6,6 +6,7 @@ represented as floats which can be negative as well as positive.
 """
 import logging
 import numpy as np
+from astropy import units as u
 
 class TimeSeries:
   def __init__(self, start=None, stop=None):
@@ -34,7 +35,7 @@ class TimeSeries:
     times:  an array of timestamps, assumed to be seconds unless
             it's an array of Quantity, in which case convert to seconds.
     """
-    ts = times.to(u.s) if hasattr(times, 'unit') else times
+    ts = times.to(u.s).value if hasattr(times, 'unit') else times
     if self.start == self.stop: # also includes both being None
       self.times = np.append(self.times, ts)
     else:
@@ -49,6 +50,7 @@ class TimeSeries:
     """
     t0 = self.start if start == None else start
     t1 = self.stop if stop == None else stop
+    #logging.debug('histogram: nbins = {}, t0 = {}, t1 = {}, times = {}'.format(nbins, t0, t1, self.times))
     if t0 == None:
       if t1 == None: # no limits, so let np.histogram optimize
         h, edges = np.histogram(self.times, bins=nbins)
@@ -58,6 +60,7 @@ class TimeSeries:
       if t1 == None: # only lower limit
         h, edges = np.histogram(self.times[self.times >= t0], bins=nbins)
       else: # both limits
+        #logging.debug('  hasattr unit self.times = {}, nbins = {}, t0 = {}, t1 = {}'.format(hasattr(self.times, 'unit'), hasattr(nbins, 'unit'), hasattr(t0, 'unit'), hasattr(t1, 'unit')))
         h, edges = np.histogram(self.times, bins=nbins, range=(t0, t1))
     return h, edges
 


### PR DESCRIPTION
This PR implements a simplified version of the top-down algorithm, which at this stage only considers signal-only neutrino lightcurves as time series, i.e., not really useful except as a proof of concept.

Some changes were also included which allow configuration files to set times with strings rather than numeric timestamps.

The csv files can be run in the usual way.  topdown.csv is for individual calculations.  topdown-series.csv is set up to run the calculation many times, with randomly generated time series based on a single true supernova direction.