### PR TITLE
Read ndof from payload for Chi2CL and Chi2Prob

### DIFF
--- a/snewpdag/plugins/Chi2CL.py
+++ b/snewpdag/plugins/Chi2CL.py
@@ -3,6 +3,7 @@ Chi2CL - take a chi2 map and turn it into CL
 
 arguments:
   in_field: field name of chi2 values
+  in_ndof_field: field name of ndof value
   out_field: field name of probability values
 
 Note that chi2 is calculated at the center of each pixel (in DiffPointing),
@@ -18,18 +19,21 @@ from scipy.stats import chi2
 from snewpdag.dag import Node
 
 class Chi2CL(Node):
-  def __init__(self, in_field, out_field, **kwargs):
+  def __init__(self, in_field, in_ndof_field, out_field, **kwargs):
     self.in_field = in_field
+    self.in_ndof_field = in_ndof_field
     self.out_field = out_field
     super().__init__(**kwargs)
 
   def alert(self, data):
     if self.in_field in data:
-      m = np.array(data[self.in_field])
-      base = np.min(m)
-      v = m - base
-      c = chi2.cdf(v, df=2)
+      #m = np.array(data[self.in_field])
+      #base = np.min(m)
+      #v = m - base
+      v = np.array(data[self.in_field])
+      c = chi2.cdf(v, df=data[self.in_ndof_field])
       data[self.out_field] = 1.0 - c
+      logging.info('chi2 range ({}, {}), ndof = {}'.format(np.min(v), np.max(v), data[self.in_ndof_field]))
       return data
     else:
       return False

--- a/snewpdag/plugins/Chi2Prob.py
+++ b/snewpdag/plugins/Chi2Prob.py
@@ -3,6 +3,7 @@ Chi2Prob - take a chi2 map and turn it into probability map
 
 arguments:
   in_field: field name of chi2 values
+  in_ndof_field: field name of ndof value
   out_field: field name of probability values
 
 Note that chi2 is calculated at the center of each pixel (in DiffPointing),
@@ -23,19 +24,21 @@ from scipy.stats import chi2
 from snewpdag.dag import Node
 
 class Chi2Prob(Node):
-  def __init__(self, in_field, out_field, **kwargs):
+  def __init__(self, in_field, in_ndof_field, out_field, **kwargs):
     self.in_field = in_field
+    self.in_ndof_field = in_ndof_field
     self.out_field = out_field
     super().__init__(**kwargs)
 
   def alert(self, data):
-    if self.in_field in data:
-      m = np.array(data[self.in_field])
-      base = np.min(m)
-      v = m - base
-      c = chi2.pdf(v, df=2)
+    if self.in_field in data and self.in_ndof_field in data:
+      #m = np.array(data[self.in_field])
+      #base = np.min(m)
+      #v = m - base
+      v = np.array(data[self.in_field])
+      c = chi2.pdf(v, df=data[self.in_ndof_field])
       sc = np.sum(c)
-      logging.info('Sum of probability map is {}'.format(sc))
+      logging.info('Sum of probability map is {}, chi2 range ({}, {}), ndof = {}'.format(sc, np.min(v), np.max(v), data[self.in_ndof_field]))
       data[self.out_field] = c / sc
       return data
     else:

--- a/snewpdag/plugins/gen/TimeDistSource.py
+++ b/snewpdag/plugins/gen/TimeDistSource.py
@@ -75,13 +75,15 @@ class TimeDistSource(Node):
           tt.append(float(tokens[tcol]))
           nn.append(float(tokens[ycol]))
           ee.append(float(tokens[ecol]))
-      self.t = np.array(tt[:-1])
-      self.thi = tt[-1]
+      #self.t = np.array(tt[:-1])
+      #self.thi = tt[-1]
       dt = np.ediff1d(tt)
       lum = np.array(nn[:-1])
       enu = np.array(ee[:-1])
       j = (enu > 0.0)
       self.mu = lum[j] * dt[j] / enu[j]
+      self.t = np.array(tt[:-1])[j]
+      self.thi = tt[-1]
 
     else:
       with open(sig_filename, 'r') as f:


### PR DESCRIPTION
Changed Chi2CL and Chi2Prob plugins to read ndof from the payload (instead of hard-wired 2, which was a kludge).  Also removed subtraction of minimum value, since that's an independent operation and in any case is usually done at the previous step.
